### PR TITLE
chore: bump zParse to `v1.0.0`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,7 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
+          name: "zParse ${{ github.ref_name }}"
           files: release/${{ env.BINARY_NAME }}
           body: ${{ steps.release-notes.outputs.NOTES }}
           draft: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 # Changelog
 
+## [v1.0.0]
+
+- Re-Write the library from scratch without using external crates
+- Add support for
+  - parsing json and toml files
+  - converting between json and toml
+  - pretty printing with customizable formatting
+  - detailed error handling
+  - zero unsafe code
+- comprehensive test coverage
+- fast and memory efficient
+- Add support for command line interface
+- Add support for library usage
+
 ## [v0.1.0]
+
 - Initial release
 - Add support for
   - parsing json and toml files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,21 +2,78 @@
 
 ## [v1.0.0]
 
-- Re-Write the library from scratch without using external crates
-- Add support for
-  - parsing json and toml files
-  - converting between json and toml
-  - pretty printing with customizable formatting
-  - detailed error handling
-  - zero unsafe code
-- comprehensive test coverage
-- fast and memory efficient
-- Add support for command line interface
-- Add support for library usage
+### Added
+- Complete rewrite of the library with zero external dependencies for core functionality
+- JSON parser
+  - Support for all JSON data types (null, boolean, number, string, array, object)
+  - Strict JSON validation
+  - Detailed error reporting with line and column information
+  - Support for nested structures
+  - Proper handling of escape sequences in strings
+
+- TOML parser
+  - Support for basic key-value pairs
+  - Table and nested table support
+  - Array tables support
+  - Inline tables and arrays
+  - Number formats (including underscores)
+  - Support for bare keys
+  - Proper whitespace handling
+
+- Format conversion
+  - Bidirectional conversion between JSON and TOML
+  - Structural preservation during conversion
+  - Proper type mapping between formats
+
+- Pretty printing
+  - Configurable indentation
+  - Optional key sorting
+  - Format-specific output styling
+  - Preservation of data structure
+
+- Error handling
+  - Custom error types with detailed messages
+  - Line and column information for syntax errors
+  - Context-aware error reporting
+  - Proper error propagation
+
+- Testing infrastructure
+  - Comprehensive unit tests
+  - Property-based tests using proptest
+  - Conversion test suite
+  - Performance benchmarks
+  - Fuzzing targets
+
+- Development tools
+  - Benchmark suite for performance monitoring
+  - Fuzzing setup for finding edge cases
+  - CI/CD pipeline with GitHub Actions
+  - Code formatting and linting checks
+  - Security audit workflow
+
+- Command line interface
+  - File parsing support
+  - Format conversion
+  - Custom output formatting
+  - Error reporting
+
+### Improved
+- Memory efficiency through string interning
+- Performance optimizations for parsing
+- Thread safety with parking_lot
+- Documentation coverage
+- Error messages and debugging information
+- Code organization and modularity
+
+### Security
+- Regular security audits through cargo-audit
+- Fuzzing infrastructure for finding vulnerabilities
+- No unsafe code usage
+- Input validation and size limits
 
 ## [v0.1.0]
 
-- Initial release
-- Add support for
-  - parsing json and toml files
-  - converting between json and toml
+### Added
+- Initial release with basic functionality
+- Basic JSON and TOML parsing
+- Simple conversion between formats

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1006,7 +1006,7 @@ dependencies = [
 
 [[package]]
 name = "zparse"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "clap",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "zparse"
-version = "0.1.0"
+version = "1.0.0"
 authors = ["Pa1Nark <pa1nark@pixincreate.dev>"]
 edition = "2021"
 rust-version = "1.82.0"
-description = "A simple JSON and TOML parser written in Rust with inter-conversions"
+description = "A robust parser and converter library for JSON and TOML files written in Rust."
 license = "GPL-3.0"
 
 [dependencies]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zparse-fuzz"
-version = "0.1.0"
+version = "1.0.0"
 publish = false
 edition = "2021"
 license = "GPL-3.0"

--- a/scripts/release_script.sh
+++ b/scripts/release_script.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+ TAG="${1:-v1.0.0}"
+
+ git tag "${TAG}" -m "zParse ${TAG}"
+ git push origin "${TAG}"


### PR DESCRIPTION
This PR bumps zParse version from `v0.1.0` to `v1.0.0`