### PR TITLE
docs: update License information in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,4 +53,4 @@ Contributions welcome! Please read our [contributing guidelines](CONTRIBUTING.md
 
 ## License
 
-Apache License 2.0
+This project is licensed under GPL-3.0. See [LICENSE](LICENSE) for more details.


### PR DESCRIPTION
This PR fixes the license mis-match that exist between the actual license that is in use and the license that is put up in README