### PR TITLE
feat(core): enforce security checks and classify errors

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -1,0 +1,3 @@
+pub mod converter;
+pub mod parser_state;
+pub mod value_compare;

--- a/src/common/converter.rs
+++ b/src/common/converter.rs
@@ -9,7 +9,7 @@ pub trait CommonConverter {
 
     fn validate_root(value: Value) -> Result<HashMap<String, Value>> {
         match value {
-            Value::Object(map) | Value::Table(map) => Ok(map),
+            Value::Map(map) => Ok(map),
             _ => Err(ParseError::new(ParseErrorKind::InvalidValue(
                 "Root must be an object/table".to_string(),
             ))),

--- a/src/common/converter.rs
+++ b/src/common/converter.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 pub trait CommonConverter {
     fn convert_map(map: HashMap<String, Value>) -> Result<Value>;
     fn convert_array(arr: Vec<Value>) -> Result<Value>;
+    fn convert_value(value: Value) -> Result<Value>;
 
     fn validate_root(value: Value) -> Result<HashMap<String, Value>> {
         match value {
@@ -15,5 +16,12 @@ pub trait CommonConverter {
         }
     }
 
-    fn convert_value(value: Value) -> Result<Value>;
+    fn convert_map_inner(map: HashMap<String, Value>) -> Result<HashMap<String, Value>> {
+        let mut new_map = HashMap::new();
+        for (key, value) in map {
+            let converted = Self::convert_value(value)?;
+            new_map.insert(key, converted);
+        }
+        Ok(new_map)
+    }
 }

--- a/src/common/converter.rs
+++ b/src/common/converter.rs
@@ -1,0 +1,19 @@
+use crate::error::{ParseError, ParseErrorKind, Result};
+use crate::parser::Value;
+use std::collections::HashMap;
+
+pub trait CommonConverter {
+    fn convert_map(map: HashMap<String, Value>) -> Result<Value>;
+    fn convert_array(arr: Vec<Value>) -> Result<Value>;
+
+    fn validate_root(value: Value) -> Result<HashMap<String, Value>> {
+        match value {
+            Value::Object(map) | Value::Table(map) => Ok(map),
+            _ => Err(ParseError::new(ParseErrorKind::InvalidValue(
+                "Root must be an object/table".to_string(),
+            ))),
+        }
+    }
+
+    fn convert_value(value: Value) -> Result<Value>;
+}

--- a/src/common/converter.rs
+++ b/src/common/converter.rs
@@ -1,4 +1,4 @@
-use crate::error::{ParseError, ParseErrorKind, Result};
+use crate::error::{LexicalError, ParseError, ParseErrorKind, Result};
 use crate::parser::Value;
 use std::collections::HashMap;
 
@@ -10,8 +10,8 @@ pub trait CommonConverter {
     fn validate_root(value: Value) -> Result<HashMap<String, Value>> {
         match value {
             Value::Map(map) => Ok(map),
-            _ => Err(ParseError::new(ParseErrorKind::InvalidValue(
-                "Root must be an object/table".to_string(),
+            _ => Err(ParseError::new(ParseErrorKind::Lexical(
+                LexicalError::InvalidToken("Root must be an object/table".to_string()),
             ))),
         }
     }

--- a/src/common/parser_state.rs
+++ b/src/common/parser_state.rs
@@ -1,5 +1,5 @@
 use crate::error::Result;
-use crate::error::{ParseError, ParseErrorKind};
+use crate::error::{ParseError, ParseErrorKind, SecurityError};
 use crate::parser::config::{ParserConfig, ParsingContext};
 
 #[derive(Debug)]
@@ -43,7 +43,9 @@ impl ParserState {
 
     pub fn validate_object_entries(&self, count: usize) -> Result<()> {
         if count > self.config.max_object_entries {
-            return Err(ParseError::new(ParseErrorKind::MaxObjectEntriesExceeded));
+            return Err(ParseError::new(ParseErrorKind::Security(
+                SecurityError::MaxObjectEntriesExceeded,
+            )));
         }
         Ok(())
     }
@@ -54,7 +56,9 @@ impl ParserState {
 
     pub fn validate_input_size(&self, size: usize) -> Result<()> {
         if size > self.config.max_size {
-            return Err(ParseError::new(ParseErrorKind::MaxSizeExceeded));
+            return Err(ParseError::new(ParseErrorKind::Security(
+                SecurityError::MaxSizeExceeded,
+            )));
         }
         Ok(())
     }

--- a/src/common/parser_state.rs
+++ b/src/common/parser_state.rs
@@ -1,0 +1,61 @@
+use crate::error::Result;
+use crate::error::{ParseError, ParseErrorKind};
+use crate::parser::config::{ParserConfig, ParsingContext};
+
+#[derive(Debug)]
+pub struct ParserState {
+    pub config: ParserConfig,
+    pub context: ParsingContext,
+}
+
+impl Default for ParserState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ParserState {
+    pub fn new() -> Self {
+        Self {
+            config: ParserConfig::default(),
+            context: ParsingContext::new(),
+        }
+    }
+
+    pub fn with_config(config: ParserConfig) -> Self {
+        Self {
+            config,
+            context: ParsingContext::new(),
+        }
+    }
+
+    pub fn enter_nested(&mut self) -> Result<()> {
+        self.context.enter_nested(&self.config)
+    }
+
+    pub fn exit_nested(&mut self) {
+        self.context.exit_nested()
+    }
+
+    pub fn validate_string(&self, s: &str) -> Result<()> {
+        self.config.validate_string(s)
+    }
+
+    pub fn validate_object_entries(&self, count: usize) -> Result<()> {
+        if count > self.config.max_object_entries {
+            return Err(ParseError::new(ParseErrorKind::MaxObjectEntriesExceeded));
+        }
+        Ok(())
+    }
+
+    pub fn add_size(&mut self, size: usize) -> Result<()> {
+        self.context.add_size(size, &self.config)
+    }
+
+    pub fn validate_input_size(&self, size: usize) -> Result<()> {
+        if size > self.config.max_size {
+            return Err(ParseError::new(ParseErrorKind::MaxSizeExceeded));
+        }
+        Ok(())
+    }
+}

--- a/src/common/value_compare.rs
+++ b/src/common/value_compare.rs
@@ -1,0 +1,32 @@
+use crate::parser::Value;
+
+pub fn values_equal(left: &Value, right: &Value) -> bool {
+    match (left, right) {
+        (Value::Object(l_map), Value::Object(r_map))
+        | (Value::Table(l_map), Value::Table(r_map))
+        | (Value::Object(l_map), Value::Table(r_map))
+        | (Value::Table(l_map), Value::Object(r_map)) => {
+            if l_map.len() != r_map.len() {
+                return false;
+            }
+            l_map
+                .iter()
+                .all(|(k, v)| r_map.get(k).is_some_and(|r_v| values_equal(v, r_v)))
+        }
+        (Value::Array(l_arr), Value::Array(r_arr)) => {
+            if l_arr.len() != r_arr.len() {
+                return false;
+            }
+            l_arr
+                .iter()
+                .zip(r_arr.iter())
+                .all(|(l, r)| values_equal(l, r))
+        }
+        (Value::Number(l), Value::Number(r)) => (l - r).abs() < f64::EPSILON,
+        (Value::String(l), Value::String(r)) => l == r,
+        (Value::Boolean(l), Value::Boolean(r)) => l == r,
+        (Value::Null, Value::Null) => true,
+        (Value::DateTime(l), Value::DateTime(r)) => l == r,
+        _ => false,
+    }
+}

--- a/src/common/value_compare.rs
+++ b/src/common/value_compare.rs
@@ -2,10 +2,7 @@ use crate::parser::Value;
 
 pub fn values_equal(left: &Value, right: &Value) -> bool {
     match (left, right) {
-        (Value::Object(l_map), Value::Object(r_map))
-        | (Value::Table(l_map), Value::Table(r_map))
-        | (Value::Object(l_map), Value::Table(r_map))
-        | (Value::Table(l_map), Value::Object(r_map)) => {
+        (Value::Map(l_map), Value::Map(r_map)) => {
             if l_map.len() != r_map.len() {
                 return false;
             }

--- a/src/converter.rs
+++ b/src/converter.rs
@@ -34,9 +34,9 @@ pub trait FormatConverter {
     fn validate_root(value: Value) -> Result<HashMap<String, Value>> {
         match value {
             Value::Map(map) => Ok(map),
-            _ => Err(ParseError::new(ParseErrorKind::Syntax(crate::error::SyntaxError::InvalidValue(
-                "Root must be an object/table".to_string(),
-            )))),
+            _ => Err(ParseError::new(ParseErrorKind::Syntax(
+                crate::error::SyntaxError::InvalidValue("Root must be an object/table".to_string()),
+            ))),
         }
     }
 

--- a/src/converter.rs
+++ b/src/converter.rs
@@ -34,9 +34,9 @@ pub trait FormatConverter {
     fn validate_root(value: Value) -> Result<HashMap<String, Value>> {
         match value {
             Value::Map(map) => Ok(map),
-            _ => Err(ParseError::new(ParseErrorKind::InvalidValue(
+            _ => Err(ParseError::new(ParseErrorKind::Syntax(crate::error::SyntaxError::InvalidValue(
                 "Root must be an object/table".to_string(),
-            ))),
+            )))),
         }
     }
 

--- a/src/converter.rs
+++ b/src/converter.rs
@@ -33,7 +33,7 @@ pub trait FormatConverter {
     /// Common validation for root value
     fn validate_root(value: Value) -> Result<HashMap<String, Value>> {
         match value {
-            Value::Object(map) | Value::Table(map) => Ok(map),
+            Value::Map(map) => Ok(map),
             _ => Err(ParseError::new(ParseErrorKind::InvalidValue(
                 "Root must be an object/table".to_string(),
             ))),

--- a/src/converter/json_to_toml.rs
+++ b/src/converter/json_to_toml.rs
@@ -28,7 +28,7 @@ impl CommonConverter for JsonToTomlConverter {
 
     fn convert_value(value: Value) -> Result<Value> {
         match value {
-            Value::Object(map) => Self::convert_map(map),
+            Value::Map(map) => Self::convert_map(map),
             Value::Array(arr) => Self::convert_array(arr),
             Value::Null => Err(ParseError::new(ParseErrorKind::InvalidValue(
                 "TOML does not support null".to_string(),

--- a/src/converter/json_to_toml.rs
+++ b/src/converter/json_to_toml.rs
@@ -4,7 +4,7 @@
 //! - Structural differences between JSON and TOML
 //! - Type mapping between formats
 //! - Validation of TOML restrictions
-//!
+
 use crate::common::converter::CommonConverter;
 use crate::error::{ParseError, ParseErrorKind, Result, SemanticError};
 use crate::parser::Value;
@@ -14,7 +14,7 @@ pub struct JsonToTomlConverter;
 
 impl CommonConverter for JsonToTomlConverter {
     fn convert_map(map: HashMap<String, Value>) -> Result<Value> {
-        let temp_map = Self::convert_map_inner(map).unwrap_or_default();
+        let temp_map = Self::convert_map_inner(map)?;
         Ok(Value::Map(temp_map))
     }
 

--- a/src/converter/json_to_toml.rs
+++ b/src/converter/json_to_toml.rs
@@ -4,42 +4,37 @@
 //! - Structural differences between JSON and TOML
 //! - Type mapping between formats
 //! - Validation of TOML restrictions
-
-use super::FormatConverter;
+//!
+use crate::common::converter::CommonConverter;
 use crate::error::{ParseError, ParseErrorKind, Result};
 use crate::parser::Value;
 use std::collections::HashMap;
 
 pub struct JsonToTomlConverter;
-impl FormatConverter for JsonToTomlConverter {
-    fn convert_root(map: HashMap<String, Value>) -> Result<Value> {
+
+impl CommonConverter for JsonToTomlConverter {
+    fn convert_map(map: HashMap<String, Value>) -> Result<Value> {
         let mut toml_map = HashMap::new();
 
         for (key, value) in map {
-            match value {
-                Value::Object(inner_map) => {
-                    toml_map.insert(key, Self::convert_root(inner_map)?);
-                }
-                Value::Array(arr) => {
-                    toml_map.insert(key, Self::convert_array(arr)?);
-                }
-                Value::Null => {
-                    return Err(ParseError::new(ParseErrorKind::InvalidValue(
-                        "TOML does not support null".to_string(),
-                    )))
-                }
-                _ => {
-                    toml_map.insert(key, value);
-                }
-            }
+            let converted = Self::convert_value(value)?;
+            toml_map.insert(key, converted);
         }
 
         Ok(Value::Table(toml_map))
     }
 
-    fn convert_array_element(value: Value) -> Result<Value> {
+    fn convert_array(arr: Vec<Value>) -> Result<Value> {
+        let converted = arr
+            .into_iter()
+            .map(Self::convert_value)
+            .collect::<Result<Vec<_>>>()?;
+        Ok(Value::Array(converted))
+    }
+
+    fn convert_value(value: Value) -> Result<Value> {
         match value {
-            Value::Object(map) => Self::convert_root(map),
+            Value::Object(map) => Self::convert_map(map),
             Value::Array(arr) => Self::convert_array(arr),
             Value::Null => Err(ParseError::new(ParseErrorKind::InvalidValue(
                 "TOML does not support null".to_string(),
@@ -58,8 +53,8 @@ impl JsonToTomlConverter {
     /// # Returns
     /// * `Ok(Value)` - The converted TOML value
     /// * `Err` - If the JSON structure cannot be represented in TOML
-    pub fn convert(json_value: Value) -> Result<Value> {
-        let map = Self::validate_root(json_value)?;
-        Self::convert_root(map)
+    pub fn convert(value: Value) -> Result<Value> {
+        let map = Self::validate_root(value)?;
+        Self::convert_map(map)
     }
 }

--- a/src/converter/json_to_toml.rs
+++ b/src/converter/json_to_toml.rs
@@ -14,14 +14,8 @@ pub struct JsonToTomlConverter;
 
 impl CommonConverter for JsonToTomlConverter {
     fn convert_map(map: HashMap<String, Value>) -> Result<Value> {
-        let mut toml_map = HashMap::new();
-
-        for (key, value) in map {
-            let converted = Self::convert_value(value)?;
-            toml_map.insert(key, converted);
-        }
-
-        Ok(Value::Table(toml_map))
+        let temp_map = Self::convert_map_inner(map).unwrap_or_default();
+        Ok(Value::Map(temp_map))
     }
 
     fn convert_array(arr: Vec<Value>) -> Result<Value> {

--- a/src/converter/json_to_toml.rs
+++ b/src/converter/json_to_toml.rs
@@ -30,8 +30,8 @@ impl CommonConverter for JsonToTomlConverter {
         match value {
             Value::Map(map) => Self::convert_map(map),
             Value::Array(arr) => Self::convert_array(arr),
-            Value::Null => Err(ParseError::new(ParseErrorKind::InvalidValue(
-                "TOML does not support null".to_string(),
+            Value::Null => Err(ParseError::new(ParseErrorKind::Syntax(
+                crate::error::SyntaxError::InvalidValue("null".to_string()),
             ))),
             _ => Ok(value),
         }

--- a/src/converter/toml_to_json.rs
+++ b/src/converter/toml_to_json.rs
@@ -1,40 +1,42 @@
-//! Converts TOML values to JSON format.
-//!
-//! Handles the complexities of converting between formats including:
-//! - Structural differences between JSON and TOML
-//! - Type mapping between formats
-//! - Validation of JSON restrictions
-
-use super::FormatConverter;
+use crate::common::converter::CommonConverter;
 use crate::error::Result;
 use crate::parser::Value;
 use std::collections::HashMap;
 
 pub struct TomlToJsonConverter;
 
-impl FormatConverter for TomlToJsonConverter {
-    fn convert_root(map: HashMap<String, Value>) -> Result<Value> {
+impl CommonConverter for TomlToJsonConverter {
+    fn convert_map(map: HashMap<String, Value>) -> Result<Value> {
         let mut json_map = HashMap::new();
 
         for (key, value) in map {
-            json_map.insert(key, Self::convert_array_element(value)?);
+            let converted = Self::convert_value(value)?;
+            json_map.insert(key, converted);
         }
 
         Ok(Value::Object(json_map))
     }
 
-    fn convert_array_element(value: Value) -> Result<Value> {
-        Ok(match value {
-            Value::Table(map) => Value::Object(map),
-            Value::Array(arr) => Self::convert_array(arr)?,
-            _ => value,
-        })
+    fn convert_array(arr: Vec<Value>) -> Result<Value> {
+        let converted = arr
+            .into_iter()
+            .map(Self::convert_value)
+            .collect::<Result<Vec<_>>>()?;
+        Ok(Value::Array(converted))
+    }
+
+    fn convert_value(value: Value) -> Result<Value> {
+        match value {
+            Value::Table(map) => Self::convert_map(map),
+            Value::Array(arr) => Self::convert_array(arr),
+            _ => Ok(value),
+        }
     }
 }
 
 impl TomlToJsonConverter {
-    pub fn convert(toml_value: Value) -> Result<Value> {
-        let map = Self::validate_root(toml_value)?;
-        Self::convert_root(map)
+    pub fn convert(value: Value) -> Result<Value> {
+        let map = Self::validate_root(value)?;
+        Self::convert_map(map)
     }
 }

--- a/src/converter/toml_to_json.rs
+++ b/src/converter/toml_to_json.rs
@@ -21,7 +21,7 @@ impl CommonConverter for TomlToJsonConverter {
 
     fn convert_value(value: Value) -> Result<Value> {
         match value {
-            Value::Table(map) => Self::convert_map(map),
+            Value::Map(map) => Self::convert_map(map),
             Value::Array(arr) => Self::convert_array(arr),
             _ => Ok(value),
         }

--- a/src/converter/toml_to_json.rs
+++ b/src/converter/toml_to_json.rs
@@ -7,14 +7,8 @@ pub struct TomlToJsonConverter;
 
 impl CommonConverter for TomlToJsonConverter {
     fn convert_map(map: HashMap<String, Value>) -> Result<Value> {
-        let mut json_map = HashMap::new();
-
-        for (key, value) in map {
-            let converted = Self::convert_value(value)?;
-            json_map.insert(key, converted);
-        }
-
-        Ok(Value::Object(json_map))
+        let json_map = Self::convert_map_inner(map).unwrap_or_default();
+        Ok(Value::Map(json_map))
     }
 
     fn convert_array(arr: Vec<Value>) -> Result<Value> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -56,6 +56,14 @@ pub enum ParseErrorKind {
     IoError(String),
     /// Error reading file
     UnknownFormat,
+    /// Maximum nesting depth exceeded
+    MaxDepthExceeded,
+    /// Maximum input size exceeded
+    MaxSizeExceeded,
+    /// Maximum string length exceeded
+    MaxStringLengthExceeded,
+    /// Maximum number of object entries exceeded
+    MaxObjectEntriesExceeded,
 }
 
 impl ParseError {

--- a/src/error.rs
+++ b/src/error.rs
@@ -90,7 +90,7 @@ pub enum SemanticError {
     NestedTableError,
     /// Type mismatch error
     TypeMismatch(String),
-    /// Error parsing a file due to unknwon format
+    /// Error parsing a file due to unknown format
     UnknownFormat,
 }
 

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -39,7 +39,7 @@ pub trait CommonFormatter {
             Value::String(s) => format!("\"{}\"", s),
             Value::DateTime(dt) => format!("\"{}\"", dt),
             Value::Array(_) => helpers::format_empty_array(),
-            Value::Object(_) | Value::Table(_) => helpers::format_empty_object(),
+            Value::Map(_) => helpers::format_empty_object(),
         }
     }
 
@@ -64,7 +64,7 @@ pub trait CommonFormatter {
 
     /// Checks if an array contains tables
     fn is_table_array(arr: &[Value]) -> bool {
-        arr.iter().any(|v| matches!(v, Value::Table(_)))
+        arr.iter().any(|v| matches!(v, Value::Map(_)))
     }
 }
 

--- a/src/formatter/json.rs
+++ b/src/formatter/json.rs
@@ -16,7 +16,7 @@ impl JsonFormatter {
     fn format_value(value: &Value, indent: usize, config: &FormatConfig) -> String {
         match value {
             Value::Array(arr) => Self::format_array(arr, indent, config),
-            Value::Object(map) | Value::Table(map) => Self::format_object(map, indent, config),
+            Value::Map(map) => Self::format_object(map, indent, config),
             _ => Self::format_basic_value(value),
         }
     }

--- a/src/formatter/toml.rs
+++ b/src/formatter/toml.rs
@@ -9,7 +9,7 @@ impl CommonFormatter for TomlFormatter {}
 impl Formatter for TomlFormatter {
     fn format(&self, value: &Value, config: &FormatConfig) -> String {
         match value {
-            Value::Table(map) => Self::format_table(map, vec![], config),
+            Value::Map(map) => Self::format_table(map, vec![], config),
             _ => Value::to_string(value),
         }
     }
@@ -27,7 +27,7 @@ impl TomlFormatter {
         // Process simple key-value pairs first
         for (key, value) in entries.iter() {
             match value {
-                Value::Table(_) | Value::Array(_) => continue,
+                Value::Map(_) | Value::Array(_) => continue,
                 _ => {
                     result.push_str(&format!("{} = {}\n", key, Self::format_basic_value(value)));
                 }
@@ -37,7 +37,7 @@ impl TomlFormatter {
         // Process tables and arrays
         for (key, value) in entries {
             match value {
-                Value::Table(inner_map) => {
+                Value::Map(inner_map) => {
                     Self::format_regular_table(&mut result, inner_map, key, path.clone(), config);
                 }
                 Value::Array(arr) if Self::is_table_array(arr) => {
@@ -76,7 +76,7 @@ impl TomlFormatter {
         config: &FormatConfig,
     ) {
         for item in arr {
-            if let Value::Table(inner_map) = item {
+            if let Value::Map(inner_map) = item {
                 path.push(key.to_string());
                 result.push_str(&format!("\n[[{}]]\n", path.join(".")));
                 result.push_str(&Self::format_table(inner_map, path.clone(), config));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,11 +25,15 @@ pub mod error;
 pub mod formatter;
 pub mod parser;
 pub mod utils;
+pub mod common;
 
+// Re-exports
 pub use converter::Converter;
 pub use error::{ParseError, ParseErrorKind, Result};
 pub use parser::{json::JsonParser, toml::TomlParser, value::Value};
 use utils::{parse_json, parse_toml};
+
+pub use common::value_compare::values_equal;
 
 #[instrument]
 pub fn parse_file(path: &str) -> Result<Value> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,19 +17,19 @@
 //! }
 //! ```
 
-use tracing::{debug, error, info, instrument, warn};
+use tracing::{debug, info, instrument, warn};
 
+pub mod common;
 pub mod converter;
 pub mod enums;
 pub mod error;
 pub mod formatter;
 pub mod parser;
 pub mod utils;
-pub mod common;
 
 // Re-exports
 pub use converter::Converter;
-pub use error::{ParseError, ParseErrorKind, Result};
+pub use error::{IOError, ParseError, ParseErrorKind, Result, SemanticError};
 pub use parser::{json::JsonParser, toml::TomlParser, value::Value};
 use utils::{parse_json, parse_toml};
 
@@ -39,10 +39,8 @@ pub use common::value_compare::values_equal;
 pub fn parse_file(path: &str) -> Result<Value> {
     debug!("Starting to parse file: {}", path);
 
-    let content = std::fs::read_to_string(path).map_err(|e| {
-        error!("Failed to read file: {}", e);
-        ParseError::new(ParseErrorKind::IoError(e.to_string()))
-    })?;
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| ParseError::new(ParseErrorKind::IO(IOError::ReadError(e.to_string()))))?;
 
     info!("File read successfully, determining format");
 
@@ -52,7 +50,9 @@ pub fn parse_file(path: &str) -> Result<Value> {
         parse_toml(&content)
     } else {
         warn!("Unknown file extension");
-        Err(ParseError::new(ParseErrorKind::UnknownFormat))
+        Err(ParseError::new(ParseErrorKind::Semantic(
+            SemanticError::UnknownFormat,
+        )))
     };
 
     debug!("Parsing completed");

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 use std::path::Path;
 use zparse::{
     converter::Converter,
-    error::{ParseError, ParseErrorKind, Result},
+    error::{ParseError, ParseErrorKind, Result, SemanticError, SyntaxError},
     utils::{format_json, format_toml, parse_json, parse_toml, read_file, write_file},
 };
 
@@ -33,9 +33,9 @@ fn main() -> Result<()> {
         .extension()
         .and_then(|ext| ext.to_str())
         .ok_or_else(|| {
-            ParseError::new(ParseErrorKind::InvalidValue(
-                "Invalid file extension".to_string(),
-            ))
+            ParseError::new(ParseErrorKind::Syntax(SyntaxError::InvalidValue(
+                "file extension".to_string(),
+            )))
         })?;
 
     // Parse input
@@ -43,8 +43,8 @@ fn main() -> Result<()> {
         "json" => parse_json(&content)?,
         "toml" => parse_toml(&content)?,
         _ => {
-            return Err(ParseError::new(ParseErrorKind::InvalidValue(
-                "Unsupported file format".to_string(),
+            return Err(ParseError::new(ParseErrorKind::Semantic(
+                SemanticError::InvalidFormat,
             )))
         }
     };
@@ -55,8 +55,8 @@ fn main() -> Result<()> {
             ("json", "toml") => (Converter::json_to_toml(parsed_value)?, "toml"),
             ("toml", "json") => (Converter::toml_to_json(parsed_value)?, "json"),
             _ => {
-                return Err(ParseError::new(ParseErrorKind::InvalidValue(
-                    "Invalid conversion".to_string(),
+                return Err(ParseError::new(ParseErrorKind::Syntax(
+                    SyntaxError::InvalidValue("conversion".to_string()),
                 )))
             }
         }
@@ -69,8 +69,8 @@ fn main() -> Result<()> {
         "json" => format_json(&final_value),
         "toml" => format_toml(&final_value),
         _ => {
-            return Err(ParseError::new(ParseErrorKind::InvalidValue(
-                "Invalid output format".to_string(),
+            return Err(ParseError::new(ParseErrorKind::Semantic(
+                SemanticError::UnknownFormat,
             )))
         }
     };

--- a/src/parser/config.rs
+++ b/src/parser/config.rs
@@ -1,3 +1,5 @@
+use crate::error::{ParseError, ParseErrorKind, Result};
+
 /// Configuration for parser limits and validation
 #[derive(Debug, Clone)]
 pub struct ParserConfig {
@@ -11,6 +13,13 @@ pub struct ParserConfig {
     pub max_object_entries: usize,
 }
 
+/// Tracks memory usage and nesting depth during parsing
+#[derive(Debug)]
+pub struct ParsingContext {
+    current_depth: usize,
+    current_size: usize,
+}
+
 impl Default for ParserConfig {
     fn default() -> Self {
         Self {
@@ -19,5 +28,56 @@ impl Default for ParserConfig {
             max_string_length: 1024 * 1024, // 1MB
             max_object_entries: 10000,
         }
+    }
+}
+
+impl ParserConfig {
+    pub fn validate_string(&self, s: &str) -> Result<()> {
+        if s.len() > self.max_string_length {
+            return Err(ParseError::new(ParseErrorKind::MaxStringLengthExceeded));
+        }
+        Ok(())
+    }
+
+    pub fn validate_object_entries(&self, count: usize) -> Result<()> {
+        if count > self.max_object_entries {
+            return Err(ParseError::new(ParseErrorKind::MaxObjectEntriesExceeded));
+        }
+        Ok(())
+    }
+}
+
+impl Default for ParsingContext {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ParsingContext {
+    pub fn new() -> Self {
+        Self {
+            current_depth: 0,
+            current_size: 0,
+        }
+    }
+
+    pub fn enter_nested(&mut self, config: &ParserConfig) -> Result<()> {
+        self.current_depth += 1;
+        if self.current_depth > config.max_depth {
+            return Err(ParseError::new(ParseErrorKind::MaxDepthExceeded));
+        }
+        Ok(())
+    }
+
+    pub fn exit_nested(&mut self) {
+        self.current_depth -= 1;
+    }
+
+    pub fn add_size(&mut self, size: usize, config: &ParserConfig) -> Result<()> {
+        self.current_size += size;
+        if self.current_size > config.max_size {
+            return Err(ParseError::new(ParseErrorKind::MaxSizeExceeded));
+        }
+        Ok(())
     }
 }

--- a/src/parser/config.rs
+++ b/src/parser/config.rs
@@ -43,14 +43,18 @@ impl Default for ParserConfig {
 impl ParserConfig {
     pub fn validate_string(&self, s: &str) -> Result<()> {
         if s.len() > self.max_string_length {
-            return Err(ParseError::new(ParseErrorKind::MaxStringLengthExceeded));
+            return Err(ParseError::new(ParseErrorKind::Security(
+                crate::error::SecurityError::MaxStringLengthExceeded,
+            )));
         }
         Ok(())
     }
 
     pub fn validate_object_entries(&self, count: usize) -> Result<()> {
         if count > self.max_object_entries {
-            return Err(ParseError::new(ParseErrorKind::MaxObjectEntriesExceeded));
+            return Err(ParseError::new(ParseErrorKind::Security(
+                crate::error::SecurityError::MaxObjectEntriesExceeded,
+            )));
         }
         Ok(())
     }
@@ -73,7 +77,9 @@ impl ParsingContext {
     pub fn enter_nested(&mut self, config: &ParserConfig) -> Result<()> {
         self.current_depth += 1;
         if self.current_depth > config.max_depth {
-            return Err(ParseError::new(ParseErrorKind::MaxDepthExceeded));
+            return Err(ParseError::new(ParseErrorKind::Security(
+                crate::error::SecurityError::MaxDepthExceeded,
+            )));
         }
         Ok(())
     }
@@ -87,7 +93,9 @@ impl ParsingContext {
     pub fn add_size(&mut self, size: usize, config: &ParserConfig) -> Result<()> {
         self.current_size += size;
         if self.current_size > config.max_size {
-            return Err(ParseError::new(ParseErrorKind::MaxSizeExceeded));
+            return Err(ParseError::new(ParseErrorKind::Security(
+                crate::error::SecurityError::MaxSizeExceeded,
+            )));
         }
         Ok(())
     }

--- a/src/parser/config.rs
+++ b/src/parser/config.rs
@@ -1,8 +1,12 @@
 use crate::error::{ParseError, ParseErrorKind, Result};
 
+/// Maximum nesting depth (32) based on common JSON/TOML usage patterns
 pub const DEFAULT_MAX_DEPTH: usize = 32;
+/// Maximum input size (1MB) to prevent memory exhaustion attacks
 pub const DEFAULT_MAX_SIZE: usize = 1_048_576; // 1MB
+/// Maximum string length (100KB) to prevent buffer overflows
 pub const DEFAULT_MAX_STRING_LENGTH: usize = 102_400; // 100KB
+/// Maximum number of object entries (1K) to prevent abuse
 pub const DEFAULT_MAX_OBJECT_ENTRIES: usize = 1_000;
 
 /// Configuration for parser limits and validation

--- a/src/parser/config.rs
+++ b/src/parser/config.rs
@@ -15,8 +15,8 @@ impl Default for ParserConfig {
     fn default() -> Self {
         Self {
             max_depth: 100,
-            max_size: 10 * 1024 * 1024, // 10MB
-            max_string_length: 1000000,
+            max_size: 10 * 1024 * 1024,     // 10MB
+            max_string_length: 1024 * 1024, // 1MB
             max_object_entries: 10000,
         }
     }

--- a/src/parser/config.rs
+++ b/src/parser/config.rs
@@ -1,5 +1,10 @@
 use crate::error::{ParseError, ParseErrorKind, Result};
 
+pub const DEFAULT_MAX_DEPTH: usize = 32;
+pub const DEFAULT_MAX_SIZE: usize = 1_048_576; // 1MB
+pub const DEFAULT_MAX_STRING_LENGTH: usize = 102_400; // 100KB
+pub const DEFAULT_MAX_OBJECT_ENTRIES: usize = 1_000;
+
 /// Configuration for parser limits and validation
 #[derive(Debug, Clone)]
 pub struct ParserConfig {
@@ -16,17 +21,17 @@ pub struct ParserConfig {
 /// Tracks memory usage and nesting depth during parsing
 #[derive(Debug)]
 pub struct ParsingContext {
-    current_depth: usize,
+    pub current_depth: usize,
     current_size: usize,
 }
 
 impl Default for ParserConfig {
     fn default() -> Self {
         Self {
-            max_depth: 100,
-            max_size: 10 * 1024 * 1024,     // 10MB
-            max_string_length: 1024 * 1024, // 1MB
-            max_object_entries: 10000,
+            max_depth: DEFAULT_MAX_DEPTH,
+            max_size: DEFAULT_MAX_SIZE,
+            max_string_length: DEFAULT_MAX_STRING_LENGTH,
+            max_object_entries: DEFAULT_MAX_OBJECT_ENTRIES,
         }
     }
 }
@@ -70,7 +75,9 @@ impl ParsingContext {
     }
 
     pub fn exit_nested(&mut self) {
-        self.current_depth -= 1;
+        if self.current_depth > 0 {
+            self.current_depth -= 1;
+        }
     }
 
     pub fn add_size(&mut self, size: usize, config: &ParserConfig) -> Result<()> {

--- a/src/parser/json.rs
+++ b/src/parser/json.rs
@@ -117,7 +117,7 @@ impl JsonParser {
         if matches!(self.current_token, Token::RightBrace) {
             self.advance()?;
             self.state.exit_nested();
-            return Ok(Value::Object(map));
+            return Ok(Value::Map(map));
         }
 
         loop {
@@ -170,7 +170,7 @@ impl JsonParser {
                 Token::RightBrace => {
                     self.advance()?;
                     self.state.exit_nested();
-                    return Ok(Value::Object(map));
+                    return Ok(Value::Map(map));
                 }
                 _ => {
                     return Err(ParseError::new(ParseErrorKind::UnexpectedToken(

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -130,7 +130,7 @@ impl Lexer {
                         Ok(Token::String(s))
                     }
                 }
-                _ => Err(ParseError::new(ParseErrorKind::InvalidToken(c.to_string()))),
+                _ => Err(ParseError::new(ParseErrorKind::InvalidToken(format!("Unexpected character '{}' at position {}", c, self.position)))),
             },
         }
     }

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -11,6 +11,7 @@ use string_parser::read_string;
 
 use crate::enums::Token;
 use crate::error::{ParseError, ParseErrorKind, Result};
+use crate::parser::config::ParserConfig;
 
 /// The core Lexer struct that other modules will use
 #[derive(Debug)]
@@ -23,6 +24,8 @@ pub struct Lexer {
     pub(crate) current_char: Option<char>,
     /// Whether we're in JSON mode (affects string quoting rules, bare keys, etc.)
     pub(crate) is_json_mode: bool,
+    /// Configuration for the parser
+    pub(crate) config: ParserConfig,
 }
 
 impl Lexer {
@@ -35,6 +38,7 @@ impl Lexer {
             position: 0,
             current_char,
             is_json_mode: false,
+            config: ParserConfig::default(),
         }
     }
 

--- a/src/parser/lexer/number_parser.rs
+++ b/src/parser/lexer/number_parser.rs
@@ -25,7 +25,9 @@ pub(crate) fn read_number(lexer: &mut Lexer) -> Result<f64> {
             '_' => {
                 // Underscores must follow a digit (and not another underscore)
                 if !has_digits || previous_char_was_underscore {
-                    return Err(ParseError::new(ParseErrorKind::InvalidNumber(number_str)));
+                    return Err(ParseError::new(ParseErrorKind::Lexical(
+                        crate::error::LexicalError::InvalidNumber(number_str),
+                    )));
                 }
                 previous_char_was_underscore = true;
                 lexer.advance();
@@ -33,7 +35,9 @@ pub(crate) fn read_number(lexer: &mut Lexer) -> Result<f64> {
             '.' => {
                 // Only allow a single decimal point, and not immediately after '_'
                 if is_float || previous_char_was_underscore {
-                    return Err(ParseError::new(ParseErrorKind::InvalidNumber(number_str)));
+                    return Err(ParseError::new(ParseErrorKind::Lexical(
+                        crate::error::LexicalError::InvalidNumber(number_str),
+                    )));
                 }
                 is_float = true;
                 previous_char_was_underscore = false;
@@ -45,14 +49,18 @@ pub(crate) fn read_number(lexer: &mut Lexer) -> Result<f64> {
     }
 
     if !has_digits {
-        return Err(ParseError::new(ParseErrorKind::InvalidNumber(number_str)));
+        return Err(ParseError::new(ParseErrorKind::Lexical(
+            crate::error::LexicalError::InvalidNumber(number_str),
+        )));
     }
 
     // Remove underscores from the string that will be parsed
     let clean_number_str: String = number_str.chars().filter(|&c| c != '_').collect();
 
     // Attempt to parse
-    clean_number_str
-        .parse::<f64>()
-        .map_err(|_| ParseError::new(ParseErrorKind::InvalidNumber(number_str)))
+    clean_number_str.parse::<f64>().map_err(|_| {
+        ParseError::new(ParseErrorKind::Lexical(
+            crate::error::LexicalError::InvalidNumber(number_str),
+        ))
+    })
 }

--- a/src/parser/lexer/string_parser.rs
+++ b/src/parser/lexer/string_parser.rs
@@ -10,7 +10,9 @@ pub(crate) fn read_string(lexer: &mut Lexer) -> Result<String> {
 
     while let Some(c) = lexer.current_char {
         if result.len() >= max_length {
-            return Err(ParseError::new(ParseErrorKind::MaxStringLengthExceeded));
+            return Err(ParseError::new(ParseErrorKind::Security(
+                crate::error::SecurityError::MaxStringLengthExceeded,
+            )));
         }
 
         match c {
@@ -30,15 +32,17 @@ pub(crate) fn read_string(lexer: &mut Lexer) -> Result<String> {
                         '\\' => '\\',
                         '"' => '"',
                         _ => {
-                            return Err(ParseError::new(ParseErrorKind::InvalidEscape(
-                                escape_char,
+                            return Err(ParseError::new(ParseErrorKind::Lexical(
+                                crate::error::LexicalError::InvalidEscape(escape_char),
                             )));
                         }
                     };
                     result.push(escaped);
                     lexer.advance();
                 } else {
-                    return Err(ParseError::new(ParseErrorKind::UnexpectedEOF));
+                    return Err(ParseError::new(ParseErrorKind::Lexical(
+                        crate::error::LexicalError::UnexpectedEOF,
+                    )));
                 }
             }
             _ => {
@@ -49,5 +53,7 @@ pub(crate) fn read_string(lexer: &mut Lexer) -> Result<String> {
     }
 
     // If we exit the while loop, we ran out of characters before finding a closing quote
-    Err(ParseError::new(ParseErrorKind::UnexpectedEOF))
+    Err(ParseError::new(ParseErrorKind::Lexical(
+        crate::error::LexicalError::UnexpectedEOF,
+    )))
 }

--- a/src/parser/lexer/string_parser.rs
+++ b/src/parser/lexer/string_parser.rs
@@ -6,8 +6,13 @@ pub(crate) fn read_string(lexer: &mut Lexer) -> Result<String> {
     lexer.advance();
 
     let mut result = String::new();
+    let max_length = lexer.config.max_string_length;
 
     while let Some(c) = lexer.current_char {
+        if result.len() >= max_length {
+            return Err(ParseError::new(ParseErrorKind::MaxStringLengthExceeded));
+        }
+
         match c {
             '"' => {
                 // Reached the closing quote

--- a/src/parser/toml.rs
+++ b/src/parser/toml.rs
@@ -75,7 +75,7 @@ impl TomlParser {
             }
         }
 
-        Ok(Value::Table(self.tables.clone()))
+        Ok(Value::Map(self.tables.clone()))
     }
 
     fn parse_table_header(&mut self) -> Result<()> {
@@ -175,9 +175,9 @@ impl TomlParser {
 
             // Handle existing key
             match current.get(key) {
-                Some(Value::Table(_)) => {
+                Some(Value::Map(_)) => {
                     current = match current.get_mut(key) {
-                        Some(Value::Table(table)) => table,
+                        Some(Value::Map(table)) => table,
                         _ => return Err(ParseError::new(ParseErrorKind::NestedTableError)),
                     };
                 }
@@ -192,9 +192,9 @@ impl TomlParser {
                 }
                 None => {
                     // Create new table
-                    current.insert(key.clone(), Value::Table(HashMap::new()));
+                    current.insert(key.clone(), Value::Map(HashMap::new()));
                     current = match current.get_mut(key) {
-                        Some(Value::Table(table)) => table,
+                        Some(Value::Map(table)) => table,
                         _ => return Err(ParseError::new(ParseErrorKind::NestedTableError)),
                     };
                 }
@@ -240,9 +240,9 @@ impl TomlParser {
         let mut current = &mut self.tables;
         for table_key in &self.current_table {
             current = match current.get_mut(table_key) {
-                Some(Value::Table(table)) => table,
+                Some(Value::Map(table)) => table,
                 Some(Value::Array(arr)) => {
-                    if let Some(Value::Table(table)) = arr.last_mut() {
+                    if let Some(Value::Map(table)) = arr.last_mut() {
                         table
                     } else {
                         return Err(ParseError::new(ParseErrorKind::NestedTableError));
@@ -337,7 +337,7 @@ impl TomlParser {
         if self.current_token == Token::RightBrace {
             self.advance()?;
             self.context.exit_nested();
-            return Ok(Value::Table(map));
+            return Ok(Value::Map(map));
         }
 
         loop {
@@ -388,7 +388,7 @@ impl TomlParser {
         }
 
         self.context.exit_nested();
-        Ok(Value::Table(map))
+        Ok(Value::Map(map))
     }
 
     fn get_or_create_array_table(&mut self, path: &[String]) -> Result<()> {
@@ -409,11 +409,11 @@ impl TomlParser {
                     // Last key - create an array
                     current.insert(
                         key.clone(),
-                        Value::Array(vec![Value::Table(HashMap::new())]),
+                        Value::Array(vec![Value::Map(HashMap::new())]),
                     );
                 } else {
                     // Intermediate key - create a table
-                    current.insert(key.clone(), Value::Table(HashMap::new()));
+                    current.insert(key.clone(), Value::Map(HashMap::new()));
                 }
             } else {
                 // Handle existing key
@@ -423,7 +423,7 @@ impl TomlParser {
                         Some(Value::Array(arr)) => {
                             // Validate array size
                             self.config.validate_object_entries(arr.len() + 1)?;
-                            arr.push(Value::Table(HashMap::new()));
+                            arr.push(Value::Map(HashMap::new()));
                         }
                         _ => return Err(ParseError::new(ParseErrorKind::NestedTableError)),
                     }
@@ -432,9 +432,9 @@ impl TomlParser {
 
             // Move to next level
             current = match current.get_mut(key) {
-                Some(Value::Table(table)) => table,
+                Some(Value::Map(table)) => table,
                 Some(Value::Array(arr)) => {
-                    if let Some(Value::Table(table)) = arr.last_mut() {
+                    if let Some(Value::Map(table)) = arr.last_mut() {
                         table
                     } else {
                         return Err(ParseError::new(ParseErrorKind::NestedTableError));

--- a/src/parser/value.rs
+++ b/src/parser/value.rs
@@ -20,11 +20,9 @@ pub enum Value {
     /// Represents an array of values
     Array(Vec<Value>),
     /// Represents a JSON object or TOML table
-    Object(HashMap<String, Value>),
+    Map(HashMap<String, Value>),
     /// Represents a TOML datetime
     DateTime(String),
-    /// Represents a TOML table
-    Table(HashMap<String, Value>),
 }
 
 impl fmt::Display for Value {
@@ -45,7 +43,7 @@ impl fmt::Display for Value {
                 }
                 write!(f, "]")
             }
-            Self::Object(obj) | Self::Table(obj) => {
+            Self::Map(obj) => {
                 write!(f, "{{")?;
                 for (i, (key, val)) in obj.iter().enumerate() {
                     if i > 0 {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,26 +1,18 @@
 use crate::{
-    error::{ParseError, ParseErrorKind, Result},
+    error::{IOError, ParseError, ParseErrorKind, Result},
     formatter::{FormatConfig, Formatter, JsonFormatter, TomlFormatter},
     parser::{json::JsonParser, toml::TomlParser, value::Value},
 };
 use std::fs;
 
 pub fn read_file(path: &str) -> Result<String> {
-    fs::read_to_string(path).map_err(|_| {
-        ParseError::new(ParseErrorKind::IoError(format!(
-            "Cannot read file: {}",
-            path
-        )))
-    })
+    fs::read_to_string(path)
+        .map_err(|_| ParseError::new(ParseErrorKind::IO(IOError::ReadError(path.to_string()))))
 }
 
 pub fn write_file(path: &str, content: &str) -> Result<()> {
-    fs::write(path, content).map_err(|_| {
-        ParseError::new(ParseErrorKind::IoError(format!(
-            "Cannot write to file: {}",
-            path
-        )))
-    })
+    fs::write(path, content)
+        .map_err(|_| ParseError::new(ParseErrorKind::IO(IOError::WriteError(path.to_string()))))
 }
 
 pub fn parse_json(content: &str) -> Result<Value> {

--- a/tests/conversion_tests.rs
+++ b/tests/conversion_tests.rs
@@ -17,10 +17,7 @@ fn read_test_file(path: &str) -> String {
 
 fn compare_values(left: &Value, right: &Value) -> bool {
     match (left, right) {
-        (Value::Object(l_map), Value::Object(r_map))
-        | (Value::Table(l_map), Value::Table(r_map))
-        | (Value::Object(l_map), Value::Table(r_map))
-        | (Value::Table(l_map), Value::Object(r_map)) => {
+        (Value::Map(l_map), Value::Map(r_map)) => {
             if l_map.len() != r_map.len() {
                 return false;
             }
@@ -129,7 +126,7 @@ fn test_specific_value_conversions() {
     );
 
     // Test specific fields are present and have correct values
-    if let (Value::Object(json_map), Value::Table(toml_map)) = (&json_value, &toml_value) {
+    if let (Value::Map(json_map), Value::Map(toml_map)) = (&json_value, &toml_value) {
         // Check success field
         assert!(compare_values(
             json_map.get("success").unwrap(),

--- a/tests/conversion_tests.rs
+++ b/tests/conversion_tests.rs
@@ -5,8 +5,9 @@
 
 use std::fs;
 use zparse::{
+    common::value_compare::values_equal,
     parser::{value::Value, JsonParser, TomlParser},
-    utils::{format_json, format_toml},
+    utils::format_json,
     Converter,
 };
 
@@ -50,18 +51,14 @@ fn test_json_to_toml_conversion() {
     let mut json_parser = JsonParser::new(&json_input).unwrap();
     let json_value = json_parser.parse().unwrap();
 
-    let toml_value = Converter::json_to_toml(json_value).unwrap();
-
+    let toml_value = Converter::json_to_toml(json_value.clone()).unwrap();
     let expected_toml = read_test_file("tests/input/file.toml");
     let mut toml_parser = TomlParser::new(&expected_toml).unwrap();
     let expected_value = toml_parser.parse().unwrap();
 
     assert!(
-        compare_values(&toml_value, &expected_value),
-        "JSON to TOML conversion produced unexpected structure.\n\
-         Got:\n{}\n\nExpected:\n{}",
-        format_toml(&toml_value),
-        expected_toml
+        values_equal(&toml_value, &expected_value),
+        "Values don't match after conversion"
     );
 }
 

--- a/tests/io_tests.rs
+++ b/tests/io_tests.rs
@@ -1,0 +1,147 @@
+#![allow(clippy::panic_in_result_fn)]
+#![allow(clippy::expect_used)]
+#![allow(clippy::panic)]
+#![allow(clippy::unwrap_used)]
+#![allow(clippy::indexing_slicing)]
+
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+
+use zparse::utils::{format_json, format_toml, read_file, write_file};
+use zparse::{
+    error::{ParseErrorKind, SemanticError},
+    parse_file,
+};
+
+// Helper to create a temporary file path in the system temporary directory.
+fn tmp_file_path(name: &str) -> PathBuf {
+    let mut dir = env::temp_dir();
+    dir.push("zparse_io_tests");
+    // Create the directory if it does not exist.
+    let _ = fs::create_dir_all(&dir);
+    dir.push(name);
+    dir
+}
+
+#[test]
+fn file_read_error() {
+    // Attempt reading a non-existent file should produce an error.
+    let non_existent = "nonexistent_file.json";
+    let result = parse_file(non_existent);
+    assert!(
+        result.is_err(),
+        "Expected error when reading non-existent file"
+    );
+
+    let err = result.unwrap_err();
+    match err.kind() {
+        ParseErrorKind::IO(_) => { /* expected */ }
+        other => panic!("Expected IO error, got {:?}", other),
+    }
+}
+
+#[test]
+fn read_and_write_file() {
+    // Use a unique file name for this test.
+    let temp_path = tmp_file_path("rw_test.txt");
+    let temp_path_str = temp_path.to_str().expect("valid path");
+
+    let content = "Hello, zParse!";
+    // Write file using write_file utility.
+    write_file(temp_path_str, content).expect("Failed to write file");
+
+    // Read back file using read_file utility.
+    let read_content = read_file(temp_path_str).expect("Failed to read file");
+    assert_eq!(content, read_content);
+
+    // Clean up the temporary file.
+    let _ = fs::remove_file(temp_path);
+}
+
+#[test]
+fn parse_and_format_json_file() {
+    // Create a temporary JSON file.
+    let temp_path = tmp_file_path("test.json");
+    let temp_path_str = temp_path.to_str().expect("valid path");
+
+    // A simple JSON string.
+    let json_content = r#"{
+         "key": "value",
+         "array": [1, 2, 3]
+     }"#;
+
+    fs::write(temp_path_str, json_content).expect("Failed to write JSON file");
+
+    // Use parse_file to parse the JSON file.
+    let parsed = parse_file(temp_path_str).expect("Failed to parse JSON file");
+    // Format back using the JSON formatter.
+    let formatted = format_json(&parsed);
+    // Check that the formatted output contains at least one expected element.
+    assert!(
+        formatted.contains("\"key\""),
+        "Formatted output should contain key"
+    );
+    assert!(
+        formatted.contains("value"),
+        "Formatted output should contain value"
+    );
+
+    // Clean up the temporary file.
+    let _ = fs::remove_file(temp_path);
+}
+
+#[test]
+fn parse_and_format_toml_file() {
+    // Create a temporary TOML file.
+    let temp_path = tmp_file_path("test.toml");
+    let temp_path_str = temp_path.to_str().expect("valid path");
+
+    // A simple TOML string.
+    let toml_content = r#"
+ key = "value"
+ array = [1, 2, 3]
+ "#;
+    fs::write(temp_path_str, toml_content).expect("Failed to write TOML file");
+
+    // Use parse_file to parse the TOML file.
+    let parsed = parse_file(temp_path_str).expect("Failed to parse TOML file");
+    // Format using the TOML formatter.
+    let formatted = format_toml(&parsed);
+    // Check that the formatted output contains expected key names.
+    assert!(
+        formatted.contains("key"),
+        "Formatted output should contain key"
+    );
+    assert!(
+        formatted.contains("value"),
+        "Formatted output should contain value"
+    );
+
+    // Clean up the temporary file.
+    let _ = fs::remove_file(temp_path);
+}
+
+#[test]
+fn unknown_file_extension() {
+    // Use a unique file name for this test.
+    let temp_path = tmp_file_path("unknown_test.txt");
+    let temp_path_str = temp_path.to_str().expect("valid path");
+
+    fs::write(temp_path_str, "some content").expect("Failed to write file");
+
+    let result = parse_file(temp_path_str);
+    assert!(
+        result.is_err(),
+        "Parsing a file with an unknown extension should error"
+    );
+    if let Err(err) = result {
+        match err.kind() {
+            // In our main parser, unknown extensions trigger a Semantic error with UnknownFormat.
+            ParseErrorKind::Semantic(SemanticError::UnknownFormat) => (),
+            other => panic!("Expected unknown format error, got {:?}", other),
+        }
+    }
+
+    let _ = fs::remove_file(temp_path);
+}

--- a/tests/json_tests.rs
+++ b/tests/json_tests.rs
@@ -20,7 +20,7 @@ mod json_tests {
     fn test_parse_empty_object() -> Result<(), Box<dyn std::error::Error>> {
         let input = "{}";
         let mut parser = JsonParser::new(input)?;
-        assert_eq!(parser.parse()?, Value::Object(HashMap::new()));
+        assert_eq!(parser.parse()?, Value::Map(HashMap::new()));
         Ok(())
     }
 
@@ -73,7 +73,7 @@ mod json_tests {
         expected.insert("age".to_string(), Value::Number(30.0));
         expected.insert("is_student".to_string(), Value::Boolean(false));
 
-        assert_eq!(value, Value::Object(expected));
+        assert_eq!(value, Value::Map(expected));
         Ok(())
     }
 
@@ -99,8 +99,8 @@ mod json_tests {
         let value = parser.parse()?;
 
         // Verify structure exists
-        if let Value::Object(root) = value {
-            if let Some(Value::Object(person)) = root.get("person") {
+        if let Value::Map(root) = value {
+            if let Some(Value::Map(person)) = root.get("person") {
                 assert!(person.contains_key("name"));
                 assert!(person.contains_key("contact"));
             } else {
@@ -128,7 +128,7 @@ mod json_tests {
             Value::Boolean(true),
             Value::Null,
             Value::Array(vec![Value::Number(2.5), Value::Boolean(false)]),
-            Value::Object(obj),
+            Value::Map(obj),
         ]);
 
         assert_eq!(value, expected);
@@ -151,7 +151,7 @@ mod json_tests {
         expected.insert("key1".to_string(), Value::String("value1".to_string()));
         expected.insert("key2".to_string(), Value::Number(42.0));
 
-        assert_eq!(value, Value::Object(expected));
+        assert_eq!(value, Value::Map(expected));
         Ok(())
     }
 
@@ -167,7 +167,7 @@ mod json_tests {
             Value::String("Hello\nWorld\t\"Escaped\"".to_string()),
         );
 
-        assert_eq!(value, Value::Object(expected));
+        assert_eq!(value, Value::Map(expected));
         Ok(())
     }
 
@@ -191,7 +191,7 @@ mod json_tests {
         let toml_value = Converter::json_to_toml(json_value)?;
 
         // Verify the conversion maintained the structure
-        if let Value::Table(root) = toml_value {
+        if let Value::Map(root) = toml_value {
             assert_eq!(root.get("title"), Some(&Value::String("Test".to_string())));
             assert!(root.contains_key("owner"));
             assert!(root.contains_key("database"));

--- a/tests/property_tests.rs
+++ b/tests/property_tests.rs
@@ -11,10 +11,7 @@ use zparse::{parser::JsonParser, Converter, Value};
 // Helper function to compare values structurally rather than string representation
 fn values_equal(left: &Value, right: &Value) -> bool {
     match (left, right) {
-        (Value::Object(l_map), Value::Object(r_map))
-        | (Value::Table(l_map), Value::Table(r_map))
-        | (Value::Object(l_map), Value::Table(r_map))
-        | (Value::Table(l_map), Value::Object(r_map)) => {
+        (Value::Map(l_map), Value::Map(r_map))=> {
             if l_map.len() != r_map.len() {
                 return false;
             }

--- a/tests/property_tests.rs
+++ b/tests/property_tests.rs
@@ -6,12 +6,15 @@
 
 use proptest::collection::vec;
 use proptest::prelude::*;
-use zparse::{parser::JsonParser, Converter, Value};
+use zparse::{
+    parser::{config::ParserConfig, JsonParser, Value},
+    Converter,
+};
 
 // Helper function to compare values structurally rather than string representation
 fn values_equal(left: &Value, right: &Value) -> bool {
     match (left, right) {
-        (Value::Map(l_map), Value::Map(r_map))=> {
+        (Value::Map(l_map), Value::Map(r_map)) => {
             if l_map.len() != r_map.len() {
                 return false;
             }
@@ -292,5 +295,58 @@ proptest! {
             let back_to_json = Converter::toml_to_json(toml).unwrap();
 
             prop_assert!(values_equal(&original, &back_to_json));
+        }
+
+        #[test]
+        fn test_security_limits(s in "\\PC{0,150}") {
+            let config = ParserConfig {
+                max_size: 100,
+                max_string_length: 50,
+                max_object_entries: 5,
+                max_depth: 3,
+            };
+
+            // Keep a reference to the limits we want to check
+            let max_size = config.max_size;
+            let max_string_length = config.max_string_length;
+
+            let json_str = format!(
+                r#"{{
+                    "string": "{}",
+                    "nested": {{"level2": {{"level3": {{"level4": 1}}}}}}
+                }}"#,
+                s
+            );
+
+            let result = JsonParser::new(&json_str)
+                .map(|p| p.with_config(config).parse());
+
+            match result {
+                Ok(parse_result) => {
+                    match parse_result {
+                        Ok(_) => {
+                            // Use the saved limits instead of accessing config
+                            prop_assert!(json_str.len() <= max_size,
+                                "Input size {} exceeds max {}",
+                                json_str.len(),
+                                max_size
+                            );
+                            prop_assert!(s.len() <= max_string_length,
+                                "String length {} exceeds max {}",
+                                s.len(),
+                                max_string_length
+                            );
+                        },
+                        Err(e) => {
+                            println!("Parse error: {:?}", e);
+                            prop_assert!(true, "Got expected parse error: {:?}", e);
+                        }
+                    }
+                }
+                Err(e) => {
+                    println!("Creation error: {:?}", e);
+                    prop_assert!(true, "Got expected creation error: {:?}", e);
+                }
+            }
         }
 }

--- a/tests/security_tests.rs
+++ b/tests/security_tests.rs
@@ -3,7 +3,7 @@
 #![allow(clippy::unwrap_used)]
 #![allow(clippy::indexing_slicing)]
 
-use zparse::error::ParseErrorKind;
+use zparse::error::{ParseErrorKind, SecurityError};
 use zparse::parser::config::{DEFAULT_MAX_DEPTH, DEFAULT_MAX_OBJECT_ENTRIES, DEFAULT_MAX_SIZE};
 use zparse::parser::{JsonParser, TomlParser};
 
@@ -16,7 +16,10 @@ fn test_max_input_size() {
     let result = JsonParser::new(&large_input);
     assert!(result.is_err());
     if let Err(e) = result {
-        assert!(matches!(e.kind(), ParseErrorKind::MaxSizeExceeded));
+        assert!(matches!(
+            e.kind(),
+            ParseErrorKind::Security(SecurityError::MaxSizeExceeded)
+        ));
     }
 }
 
@@ -32,7 +35,10 @@ fn test_max_object_entries() {
     let result = JsonParser::new(&json).and_then(|mut parser| parser.parse());
     assert!(result.is_err());
     if let Err(e) = result {
-        assert!(matches!(e.kind(), ParseErrorKind::MaxObjectEntriesExceeded));
+        assert!(matches!(
+            e.kind(),
+            ParseErrorKind::Security(SecurityError::MaxObjectEntriesExceeded)
+        ));
     }
 }
 
@@ -57,7 +63,10 @@ fn test_stack_overflow_prevention() {
     );
     if let Err(e) = result {
         assert!(
-            matches!(e.kind(), ParseErrorKind::MaxDepthExceeded),
+            matches!(
+                e.kind(),
+                ParseErrorKind::Security(SecurityError::MaxDepthExceeded)
+            ),
             "Expected MaxDepthExceeded, got {:?}",
             e.kind()
         );
@@ -73,7 +82,10 @@ fn test_max_string_length() {
     let result = JsonParser::new(&json).and_then(|mut parser| parser.parse());
     assert!(result.is_err());
     if let Err(e) = result {
-        assert!(matches!(e.kind(), ParseErrorKind::MaxStringLengthExceeded));
+        assert!(matches!(
+            e.kind(),
+            ParseErrorKind::Security(SecurityError::MaxStringLengthExceeded)
+        ));
     }
 }
 
@@ -92,6 +104,9 @@ fn test_max_nesting_depth() {
     let result = JsonParser::new(&json).and_then(|mut parser| parser.parse());
     assert!(result.is_err());
     if let Err(e) = result {
-        assert!(matches!(e.kind(), ParseErrorKind::MaxDepthExceeded));
+        assert!(matches!(
+            e.kind(),
+            ParseErrorKind::Security(SecurityError::MaxDepthExceeded)
+        ));
     }
 }

--- a/tests/security_tests.rs
+++ b/tests/security_tests.rs
@@ -1,0 +1,97 @@
+#![allow(clippy::panic_in_result_fn)]
+#![allow(clippy::panic)]
+#![allow(clippy::unwrap_used)]
+#![allow(clippy::indexing_slicing)]
+
+use zparse::error::ParseErrorKind;
+use zparse::parser::config::{DEFAULT_MAX_DEPTH, DEFAULT_MAX_OBJECT_ENTRIES, DEFAULT_MAX_SIZE};
+use zparse::parser::{JsonParser, TomlParser};
+
+#[test]
+fn test_max_input_size() {
+    // Create input exactly larger than max size (1MB)
+    let size = DEFAULT_MAX_SIZE + 1;
+    let large_input = "0".repeat(size);
+
+    let result = JsonParser::new(&large_input);
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert!(matches!(e.kind(), ParseErrorKind::MaxSizeExceeded));
+    }
+}
+
+#[test]
+fn test_max_object_entries() {
+    // Create object with more than max entries (1000)
+    let mut entries = Vec::with_capacity(DEFAULT_MAX_OBJECT_ENTRIES + 1);
+    for i in 0..=DEFAULT_MAX_OBJECT_ENTRIES {
+        entries.push(format!(r#""key{}":0"#, i));
+    }
+    let json = format!("{{{}}}", entries.join(","));
+
+    let result = JsonParser::new(&json).and_then(|mut parser| parser.parse());
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert!(matches!(e.kind(), ParseErrorKind::MaxObjectEntriesExceeded));
+    }
+}
+
+#[test]
+fn test_stack_overflow_prevention() {
+    // Create deeply nested TOML structure that exceeds max_depth
+    let mut toml = String::new();
+    let mut tables = Vec::new();
+
+    // Create one more table than the max depth allows
+    for i in 0..=DEFAULT_MAX_DEPTH {
+        tables.push(format!("table{}", i));
+        let table_path = tables.join(".");
+        toml.push_str(&format!("[{}]\n", table_path));
+    }
+
+    let result = TomlParser::new(&toml).and_then(|mut parser| parser.parse());
+    assert!(
+        result.is_err(),
+        "Expected error for excessive nesting, got {:?}",
+        result
+    );
+    if let Err(e) = result {
+        assert!(
+            matches!(e.kind(), ParseErrorKind::MaxDepthExceeded),
+            "Expected MaxDepthExceeded, got {:?}",
+            e.kind()
+        );
+    }
+}
+
+#[test]
+fn test_max_string_length() {
+    // Create string larger than max length (100KB)
+    let long_string = "x".repeat(101 * 1024);
+    let json = format!(r#""{}""#, long_string);
+
+    let result = JsonParser::new(&json).and_then(|mut parser| parser.parse());
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert!(matches!(e.kind(), ParseErrorKind::MaxStringLengthExceeded));
+    }
+}
+
+#[test]
+fn test_max_nesting_depth() {
+    // Create deeply nested JSON structure
+    let mut json = String::new();
+    for _ in 0..33 {
+        // Just over max_depth of 32
+        json.push('{');
+        json.push_str(r#""x":"#);
+    }
+    json.push_str(r#""value""#);
+    json.push_str(&"}".repeat(33));
+
+    let result = JsonParser::new(&json).and_then(|mut parser| parser.parse());
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert!(matches!(e.kind(), ParseErrorKind::MaxDepthExceeded));
+    }
+}

--- a/tests/toml_tests.rs
+++ b/tests/toml_tests.rs
@@ -20,7 +20,7 @@ mod toml_tests {
     fn test_parse_empty_document() -> Result<(), Box<dyn std::error::Error>> {
         let input = "";
         let mut parser = TomlParser::new(input)?;
-        assert_eq!(parser.parse()?, Value::Table(HashMap::new()));
+        assert_eq!(parser.parse()?, Value::Map(HashMap::new()));
         Ok(())
     }
 
@@ -35,7 +35,7 @@ mod toml_tests {
         let mut parser = TomlParser::new(input)?;
         let value = parser.parse()?;
 
-        if let Value::Table(root) = value {
+        if let Value::Map(root) = value {
             assert_eq!(
                 root.get("string"),
                 Some(&Value::String("value".to_string()))
@@ -68,9 +68,9 @@ mod toml_tests {
         let mut parser = TomlParser::new(input)?;
         let value = parser.parse()?;
 
-        if let Value::Table(root) = value {
+        if let Value::Map(root) = value {
             assert!(root.contains_key("server"));
-            if let Some(Value::Table(server)) = root.get("server") {
+            if let Some(Value::Map(server)) = root.get("server") {
                 assert_eq!(
                     server.get("host"),
                     Some(&Value::String("localhost".to_string()))
@@ -98,7 +98,7 @@ mod toml_tests {
         let mut parser = TomlParser::new(input)?;
         let value = parser.parse()?;
 
-        if let Value::Table(root) = value {
+        if let Value::Map(root) = value {
             // Test numbers array
             if let Some(Value::Array(numbers)) = root.get("numbers") {
                 assert_eq!(numbers.len(), 3);
@@ -154,11 +154,11 @@ mod toml_tests {
         let mut parser = TomlParser::new(input)?;
         let value = parser.parse()?;
 
-        if let Value::Table(root) = value {
+        if let Value::Map(root) = value {
             if let Some(Value::Array(people)) = root.get("people") {
                 assert_eq!(people.len(), 2);
                 // Verify first person
-                if let Value::Table(person) = &people[0] {
+                if let Value::Map(person) = &people[0] {
                     assert_eq!(
                         person.get("name"),
                         Some(&Value::String("Alice".to_string()))
@@ -184,7 +184,7 @@ mod toml_tests {
         let mut parser = TomlParser::new(input)?;
         let value = parser.parse()?;
 
-        if let Value::Table(root) = value {
+        if let Value::Map(root) = value {
             assert_eq!(root.get("key1"), Some(&Value::String("value1".to_string())));
             assert_eq!(root.get("key2"), Some(&Value::Number(42.0)));
             assert!(root.contains_key("section"));
@@ -215,7 +215,7 @@ mod toml_tests {
         let json_value = Converter::toml_to_json(toml_value)?;
 
         // Verify the conversion maintained the structure
-        if let Value::Object(root) = json_value {
+        if let Value::Map(root) = json_value {
             assert_eq!(root.get("title"), Some(&Value::String("Test".to_string())));
             assert!(root.contains_key("owner"));
             assert!(root.contains_key("items"));

--- a/tests/toml_tests.rs
+++ b/tests/toml_tests.rs
@@ -12,7 +12,7 @@ mod toml_tests {
         parser::{config::ParserConfig, TomlParser, Value},
         utils::parse_toml,
     };
-    
+
     fn read_test_file(path: &str) -> String {
         fs::read_to_string(path).unwrap_or_else(|_| panic!("Failed to read file: {}", path))
     }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [x] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

This PR does a lot of stuff:

- Extracts common converter traits into a single place and re-uses it everywhere applicable
- Enforces security checks based on the `ParserConfig`
- Cover more tests and edge cases with unit tests

## Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

Until now, we really have a messy error handling where the errors are not classified but rather unified. We need to classify that based on the type of error that we get.
Along side that, we do not have any type validations. We need to add those just so that, the system does not run out of memory or anything as such while reading file.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

`cargo test`

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [x] I added unit tests for my changes where possible
