### PR TITLE
ci: do not run fuzz on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,11 +83,23 @@ jobs:
         with:
           save-if: ${{ github.event_name == 'push' }}
 
+      # Skip fuzz tests on Windows
       - name: Run tests (debug)
+        if: runner.os != 'Windows'
         run: cargo test --all-features --all-targets
 
+      # Windows-specific test command
+      - name: Run tests (debug) - Windows
+        if: runner.os == 'Windows'
+        run: cargo test --package zparse --all-features --all-targets
+
       - name: Run tests (release)
+        if: runner.os != 'Windows'
         run: cargo test --release --all-features --all-targets
+
+      - name: Run tests (release) - Windows
+        if: runner.os == 'Windows'
+        run: cargo test --package zparse --release --all-features --all-targets
 
       - name: Run Clippy
         run: cargo clippy --all-features --all-targets -- -D warnings

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,8 +59,19 @@ jobs:
         with:
           targets: ${{ matrix.platform.target }}
 
+      # Add cross-compilation support
+      - name: Install cross-compilation tools
+        if: matrix.platform.target == 'aarch64-apple-darwin'
+        run: |
+          brew install FiloSottile/musl-cross/musl-cross
+          rustup target add aarch64-apple-darwin
+
+      # Build the specific package
       - name: Build Binary
-        run: cargo build --release --target ${{ matrix.platform.target }}
+        run: |
+          cargo build --release --target ${{ matrix.platform.target }} -p zparse
+        env:
+          CARGO_TARGET_AARCH64_APPLE_DARWIN_LINKER: aarch64-apple-darwin-gcc
 
       - name: Prepare Asset
         shell: bash
@@ -69,11 +80,24 @@ jobs:
           cp target/${{ matrix.platform.target }}/release/zparse${{ matrix.platform.os == 'windows-latest' && '.exe' || '' }} \
              release/${{ env.BINARY_NAME }}
 
+      # Create checksum
+      - name: Generate SHA-256
+        run: |
+          cd release
+          if [ "${{ matrix.platform.os }}" = "windows-latest" ]; then
+            certutil -hashfile ${{ env.BINARY_NAME }} SHA256 | grep -v "hash" > ${{ env.BINARY_NAME }}.sha256
+          else
+            shasum -a 256 ${{ env.BINARY_NAME }} > ${{ env.BINARY_NAME }}.sha256
+          fi
+
+      # Create Release
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
           name: "zParse ${{ github.ref_name }}"
-          files: release/${{ env.BINARY_NAME }}
+          files: |
+            release/${{ env.BINARY_NAME }}
+            release/${{ env.BINARY_NAME }}.sha256
           body: ${{ steps.release-notes.outputs.NOTES }}
           draft: false
           prerelease: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,33 @@
 # Changelog
 
+## [Unreleased]
+
+### Feat
+
+- Reduce duplicate code in JSON and TOML parsers
+- Modularise the parser code for better maintainability
+- Enforce security checks for input data to prevent buffer overflows and memory leaks
+
+### Improved
+
+- Documentation coverage for all public APIs
+- Error handling and reporting for edge cases
+- Performance optimizations for parsing and conversion
+
+### CI
+
+- Stop fuzzing on windows due to compatibility issues (`libfuzzer` is not supported on Windows platform)
+- Refactor release script to automate versioning and changelog generation
+
+### Chore
+- Update dependencies to latest versions
+- Update license information in README
+- Add templates and guidelines for contributing
+
 ## [v1.0.0]
 
-### Added
+### Feat
+
 - Complete rewrite of the library with zero external dependencies for core functionality
 - JSON parser
   - Support for all JSON data types (null, boolean, number, string, array, object)
@@ -58,6 +83,7 @@
   - Error reporting
 
 ### Improved
+
 - Memory efficiency through string interning
 - Performance optimizations for parsing
 - Thread safety with parking_lot
@@ -66,6 +92,7 @@
 - Code organization and modularity
 
 ### Security
+
 - Regular security audits through cargo-audit
 - Fuzzing infrastructure for finding vulnerabilities
 - No unsafe code usage
@@ -73,7 +100,8 @@
 
 ## [v0.1.0]
 
-### Added
+### Feat
+
 - Initial release with basic functionality
 - Basic JSON and TOML parsing
 - Simple conversion between formats

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Release Process
+# 1. Update CHANGELOG.md with new version and changes
+# 2. Run release script:
+#   ```bash
+#   ./scripts/release.sh 1.0.1
+#   ```
+# 3. Wait for GitHub Actions to:
+#   - Build binaries for all platforms
+#   - Create GitHub release
+#   - Upload assets
+# 4. Verify the release at: https://github.com/pixincreate/zparse/releases
+
+set -e
+
+# Check if version is provided
+if [ -z "$1" ]; then
+    echo "Usage: $0 <version>"
+    echo "Example: $0 1.0.0"
+    exit 1
+fi
+
+VERSION="$1"
+ZPARSE_VERSION="version = \"$VERSION\""
+
+# Update version in workspace Cargo.toml
+sed -i.bak "s/^version = .*/$ZPARSE_VERSION/" Cargo.toml
+
+# Commit changes
+git add Cargo.toml
+git commit -m "chore: bump version to $VERSION"
+
+# Create and push tag
+git tag -a "v$VERSION" -m "zParse v$VERSION"
+git push origin main "v$VERSION"

--- a/scripts/release_script.sh
+++ b/scripts/release_script.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
- TAG="${1:-v1.0.0}"
-
- git tag "${TAG}" -m "zParse ${TAG}"
- git push origin "${TAG}"


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
<!-- Describe your changes in detail -->

Libfuzzer is not supported on Windows platform and is unix specific.

## Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

https://github.com/pixincreate/zParse/actions/runs/13205202991/job/36866749186?pr=15

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

CI shouldn't fail in #15

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
