### PR TITLE
ci(test): fix unit tests from running infinitely

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
   test:
     name: test-${{ matrix.runner }}
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
 
     env:
       RUSTFLAGS: "-D warnings"
@@ -83,23 +84,12 @@ jobs:
         with:
           save-if: ${{ github.event_name == 'push' }}
 
-      # Skip fuzz tests on Windows
-      - name: Run tests (debug)
-        if: runner.os != 'Windows'
-        run: cargo test --all-features --all-targets
-
-      # Windows-specific test command
-      - name: Run tests (debug) - Windows
-        if: runner.os == 'Windows'
+      # Run only zparse package tests, exclude fuzz package completely
+      - name: Run tests
         run: cargo test --package zparse --all-features --all-targets
 
       - name: Run tests (release)
-        if: runner.os != 'Windows'
-        run: cargo test --release --all-features --all-targets
-
-      - name: Run tests (release) - Windows
-        if: runner.os == 'Windows'
         run: cargo test --package zparse --release --all-features --all-targets
 
       - name: Run Clippy
-        run: cargo clippy --all-features --all-targets -- -D warnings
+        run: cargo clippy --package zparse --all-features --all-targets -- -D warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 - Update license information in README
 - Add templates and guidelines for contributing
 
-## [v1.0.0]
+## [v1.0.0] - 2025-01-26
 
 ### Feat
 
@@ -98,7 +98,7 @@
 - No unsafe code usage
 - Input validation and size limits
 
-## [v0.1.0]
+## [v0.1.0] - 2024-12-30
 
 ### Feat
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description
<!-- Describe your changes in detail -->

This PR stops fuzzing from running against PRs for infinite amount of time.

## Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

#15 now, has CI checks running indefinitely.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

CI should work

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
