### PR TITLE
refactor(core): maintain consistent error handling across the board

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,9 +120,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.12"
+version = "1.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755717a7de9ec452bf7f3f1a3099085deabd7f2962b861dae91ecd7a365903d2"
+checksum = "c7777341816418c02e033934a09f20dc0ccaf65a5201ef8a450ae0105a573fda"
 dependencies = [
  "jobserver",
  "libc",
@@ -450,6 +450,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -469,6 +479,12 @@ name = "oorandom"
 version = "11.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
@@ -762,6 +778,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -805,6 +830,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -843,6 +878,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -862,6 +923,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "wait-timeout"
@@ -966,6 +1033,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -973,6 +1056,12 @@ checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
  "windows-sys",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
@@ -1006,96 +1095,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "wit-bindgen-rt"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "byteorder",
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "zparse"
-version = "1.0.0"
-dependencies = [
- "clap",
- "criterion",
- "parking_lot",
- "proptest",
- "tracing",
-]
-
-[[package]]
-name = "zparse-fuzz"
-version = "1.0.0"
-dependencies = [
- "libfuzzer-sys",
- "zparse",
-]
-
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,6 +444,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -575,7 +584,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "rand_xorshift",
- "regex-syntax",
+ "regex-syntax 0.8.5",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -672,8 +681,17 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -684,8 +702,14 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -898,10 +922,14 @@ version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1095,3 +1095,94 @@ dependencies = [
  "libfuzzer-sys",
  "zparse",
 ]
+
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zparse"
+version = "1.0.0"
+dependencies = [
+ "clap",
+ "criterion",
+ "parking_lot",
+ "proptest",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "zparse-fuzz"
+version = "1.0.0"
+dependencies = [
+ "libfuzzer-sys",
+ "zparse",
+]

--- a/zparse/Cargo.toml
+++ b/zparse/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 clap = { version = "4.5.28", features = ["std", "derive", "help", "usage"] }
 tracing = "0.1.41"
 parking_lot = "0.12.3"
+tracing-subscriber = "0.3.19"
 
 [dev-dependencies]
 proptest = "1.6.0"

--- a/zparse/Cargo.toml
+++ b/zparse/Cargo.toml
@@ -11,7 +11,8 @@ license.workspace = true
 clap = { version = "4.5.28", features = ["std", "derive", "help", "usage"] }
 tracing = "0.1.41"
 parking_lot = "0.12.3"
-tracing-subscriber = "0.3.19"
+tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+
 
 [dev-dependencies]
 proptest = "1.6.0"

--- a/zparse/src/common/converter.rs
+++ b/zparse/src/common/converter.rs
@@ -2,16 +2,68 @@ use crate::error::{Location, ParseErrorKind, Result, SemanticError};
 use crate::parser::Value;
 use std::collections::HashMap;
 
+pub struct ConversionContext {
+    line: usize,
+    column: usize,
+    path: Vec<(String, usize, usize)>, // (key, line, column)
+}
+
+impl Default for ConversionContext {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ConversionContext {
+    pub fn new() -> Self {
+        Self {
+            line: 1,
+            column: 1,
+            path: Vec::new(),
+        }
+    }
+
+    pub fn create_location(&self) -> Location {
+        Location::new(self.line, self.column)
+    }
+
+    pub fn enter_key(&mut self, key: &str, line: usize, column: usize) {
+        self.line = line;
+        self.column = column;
+        self.path.push((key.to_string(), line, column));
+    }
+
+    pub fn exit_key(&mut self) {
+        if let Some((_, line, column)) = self.path.pop() {
+            self.line = line;
+            self.column = column;
+        }
+    }
+
+    pub fn get_path(&self) -> String {
+        self.path
+            .iter()
+            .map(|(key, _, _)| key.as_str())
+            .collect::<Vec<_>>()
+            .join(".")
+    }
+
+    pub fn update_position(&mut self, line: usize, column: usize) {
+        self.line = line;
+        self.column = column;
+    }
+}
+
 pub trait CommonConverter {
-    fn convert_map(map: HashMap<String, Value>) -> Result<Value>;
-    fn convert_array(arr: Vec<Value>) -> Result<Value>;
-    fn convert_value(value: Value) -> Result<Value>;
+    fn convert_map(map: HashMap<String, Value>, ctx: &mut ConversionContext) -> Result<Value>;
+    fn convert_array(arr: Vec<Value>, ctx: &mut ConversionContext) -> Result<Value>;
+    fn convert_value(value: Value, ctx: &mut ConversionContext) -> Result<Value>;
 
     fn validate_root(value: Value) -> Result<HashMap<String, Value>> {
         match value {
             Value::Map(map) => Ok(map),
             _ => {
-                let location = Location::new(0, 0); // Root level error
+                let location = Location::new(1, 1); // Root always starts at 1, 1
                 Err(location.create_error(
                     ParseErrorKind::Semantic(SemanticError::TypeMismatch(
                         "Root must be an object/table".to_string(),
@@ -22,18 +74,36 @@ pub trait CommonConverter {
         }
     }
 
-    fn convert_map_inner(map: HashMap<String, Value>) -> Result<HashMap<String, Value>> {
+    fn convert_map_inner(
+        map: HashMap<String, Value>,
+        ctx: &mut ConversionContext,
+    ) -> Result<HashMap<String, Value>> {
         let mut new_map = HashMap::new();
         for (key, value) in map {
-            let converted = Self::convert_value(value).map_err(|e| {
-                let location = Location::new(0, 0);
-                location.create_error(
-                    e.kind().clone(),
-                    &format!("Error converting value for key '{}'", key),
-                )
+            // Use key length to estimate column position
+            let column = ctx.column + key.len() + 2; // +2 for quotes
+            ctx.enter_key(&key, ctx.line, column);
+            let converted = Self::convert_value(value, ctx).map_err(|e| {
+                let location = ctx.create_location();
+                let path = ctx.get_path();
+                location.create_error(e.kind().clone(), &format!("Error at '{}': {}", path, e))
             })?;
             new_map.insert(key, converted);
+            ctx.exit_key();
         }
         Ok(new_map)
+    }
+
+    fn convert_array_inner(arr: Vec<Value>, ctx: &mut ConversionContext) -> Result<Vec<Value>> {
+        let mut converted_array = Vec::new();
+        for (i, value) in arr.iter().enumerate() {
+            // Estimate position based on index
+            let column = ctx.column + i * 2 + 1; // Simple estimation
+            ctx.enter_key(&i.to_string(), ctx.line, column);
+            converted_array.push(Self::convert_value(value.clone(), ctx)?);
+            ctx.exit_key();
+        }
+
+        Ok(converted_array)
     }
 }

--- a/zparse/src/common/converter.rs
+++ b/zparse/src/common/converter.rs
@@ -1,4 +1,4 @@
-use crate::error::{LexicalError, ParseError, ParseErrorKind, Result};
+use crate::error::{Location, ParseErrorKind, Result, SemanticError};
 use crate::parser::Value;
 use std::collections::HashMap;
 
@@ -10,16 +10,28 @@ pub trait CommonConverter {
     fn validate_root(value: Value) -> Result<HashMap<String, Value>> {
         match value {
             Value::Map(map) => Ok(map),
-            _ => Err(ParseError::new(ParseErrorKind::Lexical(
-                LexicalError::InvalidToken("Root must be an object/table".to_string()),
-            ))),
+            _ => {
+                let location = Location::new(0, 0); // Root level error
+                Err(location.create_error(
+                    ParseErrorKind::Semantic(SemanticError::TypeMismatch(
+                        "Root must be an object/table".to_string(),
+                    )),
+                    "Invalid root value type",
+                ))
+            }
         }
     }
 
     fn convert_map_inner(map: HashMap<String, Value>) -> Result<HashMap<String, Value>> {
         let mut new_map = HashMap::new();
         for (key, value) in map {
-            let converted = Self::convert_value(value)?;
+            let converted = Self::convert_value(value).map_err(|e| {
+                let location = Location::new(0, 0);
+                location.create_error(
+                    e.kind().clone(),
+                    &format!("Error converting value for key '{}'", key),
+                )
+            })?;
             new_map.insert(key, converted);
         }
         Ok(new_map)

--- a/zparse/src/common/converter.rs
+++ b/zparse/src/common/converter.rs
@@ -1,6 +1,9 @@
-use crate::error::{Location, ParseErrorKind, Result, SemanticError};
-use crate::parser::Value;
 use std::collections::HashMap;
+
+use crate::{
+    error::{Location, ParseErrorKind, Result, SemanticError},
+    parser::Value,
+};
 
 pub struct ConversionContext {
     line: usize,

--- a/zparse/src/common/parser_state.rs
+++ b/zparse/src/common/parser_state.rs
@@ -1,5 +1,4 @@
-use crate::error::Result;
-use crate::error::{ParseError, ParseErrorKind, SecurityError};
+use crate::error::{Location, ParseErrorKind, Result, SecurityError};
 use crate::parser::config::{ParserConfig, ParsingContext};
 
 #[derive(Debug)]
@@ -43,9 +42,14 @@ impl ParserState {
 
     pub fn validate_object_entries(&self, count: usize) -> Result<()> {
         if count > self.config.max_object_entries {
-            return Err(ParseError::new(ParseErrorKind::Security(
-                SecurityError::MaxObjectEntriesExceeded,
-            )));
+            let location = Location::new(0, 0);
+            return Err(location.create_error(
+                ParseErrorKind::Security(SecurityError::MaxObjectEntriesExceeded),
+                &format!(
+                    "Maximum object entries ({}) exceeded",
+                    self.config.max_object_entries
+                ),
+            ));
         }
         Ok(())
     }
@@ -56,9 +60,14 @@ impl ParserState {
 
     pub fn validate_input_size(&self, size: usize) -> Result<()> {
         if size > self.config.max_size {
-            return Err(ParseError::new(ParseErrorKind::Security(
-                SecurityError::MaxSizeExceeded,
-            )));
+            let location = Location::new(0, 0);
+            return Err(location.create_error(
+                ParseErrorKind::Security(SecurityError::MaxSizeExceeded),
+                &format!(
+                    "Input size ({} bytes) exceeds maximum allowed ({})",
+                    size, self.config.max_size
+                ),
+            ));
         }
         Ok(())
     }

--- a/zparse/src/common/parser_state.rs
+++ b/zparse/src/common/parser_state.rs
@@ -1,5 +1,7 @@
-use crate::error::{Location, ParseErrorKind, Result, SecurityError};
-use crate::parser::config::{ParserConfig, ParsingContext};
+use crate::{
+    error::{Location, ParseErrorKind, Result, SecurityError},
+    parser::config::{ParserConfig, ParsingContext},
+};
 
 #[derive(Debug)]
 pub struct ParserState {

--- a/zparse/src/common/value_compare.rs
+++ b/zparse/src/common/value_compare.rs
@@ -1,5 +1,6 @@
 use crate::parser::Value;
 
+// Helper function to compare values structurally rather than string representation
 pub fn values_equal(left: &Value, right: &Value) -> bool {
     match (left, right) {
         (Value::Map(l_map), Value::Map(r_map)) => {

--- a/zparse/src/converter.rs
+++ b/zparse/src/converter.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 mod json_to_toml;
 mod toml_to_json;
 
@@ -6,7 +8,6 @@ pub use toml_to_json::TomlToJsonConverter;
 
 use crate::error::{ParseError, ParseErrorKind, Result};
 use crate::parser::Value;
-use std::collections::HashMap;
 
 /// High-level “Converter” utility struct that delegates to the specialized
 /// implementations for JSON↔TOML conversions.

--- a/zparse/src/converter/json_to_toml.rs
+++ b/zparse/src/converter/json_to_toml.rs
@@ -5,49 +5,54 @@
 //! - Type mapping between formats
 //! - Validation of TOML restrictions
 
-use crate::common::converter::CommonConverter;
-use crate::error::{ConversionError, Location, ParseErrorKind, Result};
+use crate::common::converter::{CommonConverter, ConversionContext};
+use crate::error::{ConversionError, ParseErrorKind, Result};
 use crate::parser::Value;
 use std::collections::HashMap;
 
 pub struct JsonToTomlConverter;
 
 impl CommonConverter for JsonToTomlConverter {
-    fn convert_map(map: HashMap<String, Value>) -> Result<Value> {
-        let temp_map = Self::convert_map_inner(map)?;
+    fn convert_map(map: HashMap<String, Value>, ctx: &mut ConversionContext) -> Result<Value> {
+        let temp_map = Self::convert_map_inner(map, ctx)?;
         Ok(Value::Map(temp_map))
     }
 
-    fn convert_array(arr: Vec<Value>) -> Result<Value> {
+    fn convert_array(arr: Vec<Value>, ctx: &mut ConversionContext) -> Result<Value> {
         // Check for nested null values in arrays
         if arr.iter().any(|v| matches!(v, Value::Null)) {
-            let location = Location::new(0, 0);
+            let location = ctx.create_location();
+            let path = ctx.get_path();
             return Err(location.create_error(
                 ParseErrorKind::Conversion(ConversionError::UnsupportedValue(
                     "Null values in arrays".to_string(),
                 )),
-                "TOML arrays cannot contain null values",
+                &format!("Array at '{}' contains null values", path),
             ));
         }
 
-        let converted = arr
-            .into_iter()
-            .map(Self::convert_value)
-            .collect::<Result<Vec<_>>>()?;
+        let converted = Self::convert_array_inner(arr, ctx)?;
         Ok(Value::Array(converted))
     }
 
-    fn convert_value(value: Value) -> Result<Value> {
+    fn convert_value(value: Value, ctx: &mut ConversionContext) -> Result<Value> {
         match value {
-            Value::Map(map) => Self::convert_map(map),
-            Value::Array(arr) => Self::convert_array(arr),
+            Value::Map(map) => Self::convert_map(map, ctx),
+            Value::Array(arr) => Self::convert_array(arr, ctx),
             Value::Null => {
-                let location = Location::new(0, 0);
+                let location = ctx.create_location();
+                let path = ctx.get_path();
+                let context = if path.is_empty() {
+                    "Root level null value".to_string()
+                } else {
+                    format!("Null value at path: {}", path)
+                };
+
                 Err(location.create_error(
                     ParseErrorKind::Conversion(ConversionError::UnsupportedValue(
                         "Null value".to_string(),
                     )),
-                    "TOML does not support null values",
+                    &context,
                 ))
             }
             _ => Ok(value),
@@ -66,6 +71,7 @@ impl JsonToTomlConverter {
     /// * `Err` - If the JSON structure cannot be represented in TOML
     pub fn convert(value: Value) -> Result<Value> {
         let map = Self::validate_root(value)?;
-        Self::convert_map(map)
+        let mut ctx = ConversionContext::new();
+        Self::convert_map(map, &mut ctx)
     }
 }

--- a/zparse/src/converter/json_to_toml.rs
+++ b/zparse/src/converter/json_to_toml.rs
@@ -5,10 +5,13 @@
 //! - Type mapping between formats
 //! - Validation of TOML restrictions
 
-use crate::common::converter::{CommonConverter, ConversionContext};
-use crate::error::{ConversionError, ParseErrorKind, Result};
-use crate::parser::Value;
 use std::collections::HashMap;
+
+use crate::{
+    common::converter::{CommonConverter, ConversionContext},
+    error::{ConversionError, ParseErrorKind, Result},
+    parser::Value,
+};
 
 pub struct JsonToTomlConverter;
 

--- a/zparse/src/converter/toml_to_json.rs
+++ b/zparse/src/converter/toml_to_json.rs
@@ -1,4 +1,4 @@
-use crate::common::converter::CommonConverter;
+use crate::common::converter::{CommonConverter, ConversionContext};
 use crate::error::Result;
 use crate::parser::Value;
 use std::collections::HashMap;
@@ -6,23 +6,20 @@ use std::collections::HashMap;
 pub struct TomlToJsonConverter;
 
 impl CommonConverter for TomlToJsonConverter {
-    fn convert_map(map: HashMap<String, Value>) -> Result<Value> {
-        let json_map = Self::convert_map_inner(map).unwrap_or_default();
+    fn convert_map(map: HashMap<String, Value>, ctx: &mut ConversionContext) -> Result<Value> {
+        let json_map = Self::convert_map_inner(map, ctx).unwrap_or_default();
         Ok(Value::Map(json_map))
     }
 
-    fn convert_array(arr: Vec<Value>) -> Result<Value> {
-        let converted = arr
-            .into_iter()
-            .map(Self::convert_value)
-            .collect::<Result<Vec<_>>>()?;
+    fn convert_array(arr: Vec<Value>, ctx: &mut ConversionContext) -> Result<Value> {
+        let converted = Self::convert_array_inner(arr, ctx)?;
         Ok(Value::Array(converted))
     }
 
-    fn convert_value(value: Value) -> Result<Value> {
+    fn convert_value(value: Value, ctx: &mut ConversionContext) -> Result<Value> {
         match value {
-            Value::Map(map) => Self::convert_map(map),
-            Value::Array(arr) => Self::convert_array(arr),
+            Value::Map(map) => Self::convert_map(map, ctx),
+            Value::Array(arr) => Self::convert_array(arr, ctx),
             _ => Ok(value),
         }
     }
@@ -31,6 +28,7 @@ impl CommonConverter for TomlToJsonConverter {
 impl TomlToJsonConverter {
     pub fn convert(value: Value) -> Result<Value> {
         let map = Self::validate_root(value)?;
-        Self::convert_map(map)
+        let mut ctx = ConversionContext::new();
+        Self::convert_map(map, &mut ctx)
     }
 }

--- a/zparse/src/converter/toml_to_json.rs
+++ b/zparse/src/converter/toml_to_json.rs
@@ -1,7 +1,10 @@
-use crate::common::converter::{CommonConverter, ConversionContext};
-use crate::error::Result;
-use crate::parser::Value;
 use std::collections::HashMap;
+
+use crate::{
+    common::converter::{CommonConverter, ConversionContext},
+    error::Result,
+    parser::Value,
+};
 
 pub struct TomlToJsonConverter;
 

--- a/zparse/src/error.rs
+++ b/zparse/src/error.rs
@@ -149,17 +149,24 @@ impl ParseError {
 
 impl fmt::Display for ParseError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match &self.kind {
-            ParseErrorKind::IO(err) => write!(f, "IO error: {}", err),
-            ParseErrorKind::Lexical(err) => write!(f, "Lexical error: {}", err),
-            ParseErrorKind::Security(err) => write!(f, "Security error: {}", err),
-            ParseErrorKind::Semantic(err) => write!(f, "Semantic error: {}", err),
-            ParseErrorKind::Syntax(err) => write!(f, "Syntax error: {}", err),
-        }?;
+        let context = match &self.kind {
+            ParseErrorKind::IO(err) => format!("IO error occurred: {}", err),
+            ParseErrorKind::Lexical(err) => format!("Lexical analysis failed: {}", err),
+            ParseErrorKind::Security(err) => format!("Security check failed: {}", err),
+            ParseErrorKind::Semantic(err) => format!("Semantic validation failed: {}", err),
+            ParseErrorKind::Syntax(err) => format!("Syntax error encountered: {}", err),
+        };
+
+        write!(f, "{}", context)?;
 
         if let Some(loc) = &self.location {
             write!(f, " at line {}, column {}", loc.line, loc.column)?;
         }
+
+        if let Some(source) = &self.source {
+            write!(f, "\nCaused by: {}", source)?;
+        }
+
         Ok(())
     }
 }

--- a/zparse/src/error.rs
+++ b/zparse/src/error.rs
@@ -32,11 +32,19 @@ pub struct Location {
 /// Top-level error categories
 #[derive(Debug, Clone)]
 pub enum ParseErrorKind {
+    Conversion(ConversionError),
     IO(IOError),
     Lexical(LexicalError),
     Security(SecurityError),
     Semantic(SemanticError),
     Syntax(SyntaxError),
+}
+
+/// Conversion errors
+#[derive(Debug, Clone)]
+pub enum ConversionError {
+    /// Unsupported value type
+    UnsupportedValue(String),
 }
 
 /// Lexical analysis errors
@@ -165,6 +173,7 @@ impl fmt::Display for ParseError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // Start with base error description
         let base_error = match &self.kind {
+            ParseErrorKind::Conversion(err) => err.to_string(),
             ParseErrorKind::IO(err) => err.to_string(),
             ParseErrorKind::Lexical(err) => err.to_string(),
             ParseErrorKind::Security(err) => err.to_string(),
@@ -194,6 +203,14 @@ impl fmt::Display for ParseError {
         }
 
         Ok(())
+    }
+}
+
+impl fmt::Display for ConversionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnsupportedValue(v) => write!(f, "Unsupported value: '{}'", v),
+        }
     }
 }
 

--- a/zparse/src/error.rs
+++ b/zparse/src/error.rs
@@ -33,6 +33,7 @@ pub struct Location {
 #[derive(Debug, Clone)]
 pub enum ParseErrorKind {
     Conversion(ConversionError),
+    Format(FormatError),
     IO(IOError),
     Lexical(LexicalError),
     Security(SecurityError),
@@ -45,6 +46,17 @@ pub enum ParseErrorKind {
 pub enum ConversionError {
     /// Unsupported value type
     UnsupportedValue(String),
+}
+
+/// Format errors
+#[derive(Debug, Clone)]
+pub enum FormatError {
+    /// Invalid indentation in the input
+    InvalidIndentation(String),
+    /// Invalid value in the input
+    InvalidValue(String),
+    /// Error serializing a value
+    SerializationFailed(String),
 }
 
 /// Lexical analysis errors
@@ -174,6 +186,7 @@ impl fmt::Display for ParseError {
         // Start with base error description
         let base_error = match &self.kind {
             ParseErrorKind::Conversion(err) => err.to_string(),
+            ParseErrorKind::Format(err) => err.to_string(),
             ParseErrorKind::IO(err) => err.to_string(),
             ParseErrorKind::Lexical(err) => err.to_string(),
             ParseErrorKind::Security(err) => err.to_string(),
@@ -210,6 +223,16 @@ impl fmt::Display for ConversionError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::UnsupportedValue(v) => write!(f, "Unsupported value: '{}'", v),
+        }
+    }
+}
+
+impl fmt::Display for FormatError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidIndentation(i) => write!(f, "Invalid indentation: '{}'", i),
+            Self::InvalidValue(v) => write!(f, "Invalid value: '{}'", v),
+            Self::SerializationFailed(s) => write!(f, "Serialization failed: '{}'", s),
         }
     }
 }

--- a/zparse/src/error.rs
+++ b/zparse/src/error.rs
@@ -5,6 +5,8 @@
 
 use std::{error::Error, fmt};
 
+use crate::parser::lexer::Lexer;
+
 /// Main error type for parsing operations
 #[derive(Debug)]
 pub struct ParseError {
@@ -269,3 +271,25 @@ impl Error for ParseError {
 }
 
 pub type Result<T> = std::result::Result<T, ParseError>;
+
+impl Location {
+    pub fn new(line: usize, column: usize) -> Self {
+        Self { line, column }
+    }
+
+    pub fn from_lexer(lexer: &Lexer) -> Self {
+        let (line, column) = lexer.get_location();
+        Self { line, column }
+    }
+
+    pub fn create_error(&self, kind: ParseErrorKind, context: &str) -> ParseError {
+        let mut error = ParseError::new(kind);
+        error = error.with_location(self.line, self.column);
+
+        if !context.is_empty() {
+            error = error.with_context(context);
+        }
+
+        error
+    }
+}

--- a/zparse/src/formatter/json.rs
+++ b/zparse/src/formatter/json.rs
@@ -1,6 +1,7 @@
+use std::collections::HashMap;
+
 use super::{helpers, CommonFormatter, FormatConfig, Formatter};
 use crate::{error::Result, parser::Value};
-use std::collections::HashMap;
 
 pub struct JsonFormatter;
 

--- a/zparse/src/formatter/json.rs
+++ b/zparse/src/formatter/json.rs
@@ -1,5 +1,5 @@
 use super::{helpers, CommonFormatter, FormatConfig, Formatter};
-use crate::parser::Value;
+use crate::{error::Result, parser::Value};
 use std::collections::HashMap;
 
 pub struct JsonFormatter;
@@ -7,60 +7,62 @@ pub struct JsonFormatter;
 impl CommonFormatter for JsonFormatter {}
 
 impl Formatter for JsonFormatter {
-    fn format(&self, value: &Value, config: &FormatConfig) -> String {
-        Self::format_value(value, 0, config)
+    fn format(&self, value: &Value, config: &FormatConfig) -> Result<String> {
+        Ok(Self::format_value(value, 0, config))?
     }
 }
 
 impl JsonFormatter {
-    fn format_value(value: &Value, indent: usize, config: &FormatConfig) -> String {
+    fn format_value(value: &Value, indent: usize, config: &FormatConfig) -> Result<String> {
         match value {
             Value::Array(arr) => Self::format_array(arr, indent, config),
             Value::Map(map) => Self::format_object(map, indent, config),
-            _ => Self::format_basic_value(value),
+            _ => Ok(Self::format_basic_value(value)),
         }
     }
 
-    fn format_array(arr: &[Value], indent: usize, config: &FormatConfig) -> String {
+    fn format_array(arr: &[Value], indent: usize, config: &FormatConfig) -> Result<String> {
         if arr.is_empty() {
-            return helpers::format_empty_array();
+            return Ok(helpers::format_empty_array());
         }
 
-        let (indent_str, inner_indent) = Self::create_indentation(indent, config);
-        let items: Vec<String> = arr
-            .iter()
-            .map(|v| {
-                format!(
-                    "{}{}",
-                    inner_indent,
-                    Self::format_value(v, indent + 1, config)
-                )
-            })
-            .collect();
+        let (indent_str, inner_indent) = Self::create_indentation(indent, config)?;
+        let mut items = Vec::new();
 
-        format!("[\n{}\n{}]", helpers::join_with_commas(items), indent_str)
+        for v in arr {
+            let formatted = Self::format_value(v, indent + 1, config)?;
+            items.push(format!("{}{}", inner_indent, formatted));
+        }
+
+        Ok(format!(
+            "[\n{}\n{}]",
+            helpers::join_with_commas(items),
+            indent_str
+        ))
     }
 
-    fn format_object(map: &HashMap<String, Value>, indent: usize, config: &FormatConfig) -> String {
+    fn format_object(
+        map: &HashMap<String, Value>,
+        indent: usize,
+        config: &FormatConfig,
+    ) -> Result<String> {
         if map.is_empty() {
-            return helpers::format_empty_object();
+            return Ok(helpers::format_empty_object());
         }
 
-        let (indent_str, inner_indent) = Self::create_indentation(indent, config);
+        let (indent_str, inner_indent) = Self::create_indentation(indent, config)?;
         let entries = Self::sort_entries(map.iter().collect(), config);
 
-        let items: Vec<String> = entries
-            .iter()
-            .map(|(k, v)| {
-                format!(
-                    "{}\"{}\": {}",
-                    inner_indent,
-                    k,
-                    Self::format_value(v, indent + 1, config)
-                )
-            })
-            .collect();
+        let mut items = Vec::new();
+        for (k, v) in entries {
+            let formatted = Self::format_value(v, indent + 1, config)?;
+            items.push(format!("{}\"{}\": {}", inner_indent, k, formatted));
+        }
 
-        format!("{{\n{}\n{}}}", helpers::join_with_commas(items), indent_str)
+        Ok(format!(
+            "{{\n{}\n{}}}",
+            helpers::join_with_commas(items),
+            indent_str
+        ))
     }
 }

--- a/zparse/src/formatter/toml.rs
+++ b/zparse/src/formatter/toml.rs
@@ -1,5 +1,5 @@
 use super::{CommonFormatter, FormatConfig, Formatter};
-use crate::parser::Value;
+use crate::{error::Result, parser::Value};
 use std::collections::HashMap;
 
 pub struct TomlFormatter;
@@ -7,10 +7,10 @@ pub struct TomlFormatter;
 impl CommonFormatter for TomlFormatter {}
 
 impl Formatter for TomlFormatter {
-    fn format(&self, value: &Value, config: &FormatConfig) -> String {
+    fn format(&self, value: &Value, config: &FormatConfig) -> Result<String> {
         match value {
-            Value::Map(map) => Self::format_table(map, vec![], config),
-            _ => Value::to_string(value),
+            Value::Map(map) => Ok(Self::format_table(map, vec![], config)),
+            _ => Ok(Value::to_string(value)),
         }
     }
 }

--- a/zparse/src/formatter/toml.rs
+++ b/zparse/src/formatter/toml.rs
@@ -1,6 +1,7 @@
+use std::collections::HashMap;
+
 use super::{CommonFormatter, FormatConfig, Formatter};
 use crate::{error::Result, parser::Value};
-use std::collections::HashMap;
 
 pub struct TomlFormatter;
 

--- a/zparse/src/main.rs
+++ b/zparse/src/main.rs
@@ -1,5 +1,6 @@
 use clap::Parser;
 use std::path::Path;
+use tracing::{error, info};
 use zparse::{
     converter::Converter,
     error::{ParseError, ParseErrorKind, Result, SemanticError, SyntaxError},
@@ -22,10 +23,29 @@ struct Args {
     output: Option<String>,
 }
 
-fn main() -> Result<()> {
+fn main() {
+    // Initialize the default subscriber for logging
+    tracing_subscriber::fmt()
+        .with_target(false) // Don't show target
+        .with_thread_ids(false) // Don't show thread IDs
+        .with_thread_names(false) // Don't show thread names
+        .with_file(false) // Don't show file names
+        .with_line_number(false) // Don't show line numbers
+        .without_time() // Don't show timestamps
+        .init(); // Initialize the subscriber
+
+    if let Err(e) = run() {
+        // Now this will actually print
+        error!("{}", e);
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<()> {
     let args = Args::parse();
 
     // Read input file
+    info!("Reading file: {}", args.file);
     let content = read_file(&args.file)?;
 
     // Determine input format from file extension

--- a/zparse/src/main.rs
+++ b/zparse/src/main.rs
@@ -2,6 +2,7 @@ use clap::Parser;
 use std::path::Path;
 use tracing::{error, info};
 use tracing_subscriber::{fmt::format::FmtSpan, EnvFilter};
+
 use zparse::{
     converter::Converter,
     error::{ParseError, ParseErrorKind, Result, SemanticError, SyntaxError},

--- a/zparse/src/main.rs
+++ b/zparse/src/main.rs
@@ -86,8 +86,8 @@ fn run() -> Result<()> {
 
     // Format the output
     let formatted_output = match output_format {
-        "json" => format_json(&final_value),
-        "toml" => format_toml(&final_value),
+        "json" => format_json(&final_value)?,
+        "toml" => format_toml(&final_value)?,
         _ => {
             return Err(ParseError::new(ParseErrorKind::Semantic(
                 SemanticError::UnknownFormat,

--- a/zparse/src/main.rs
+++ b/zparse/src/main.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
 use std::path::Path;
 use tracing::{error, info};
+use tracing_subscriber::{fmt::format::FmtSpan, EnvFilter};
 use zparse::{
     converter::Converter,
     error::{ParseError, ParseErrorKind, Result, SemanticError, SyntaxError},
@@ -26,16 +27,15 @@ struct Args {
 fn main() {
     // Initialize the default subscriber for logging
     tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .with_span_events(FmtSpan::CLOSE)
         .with_target(false) // Don't show target
-        .with_thread_ids(false) // Don't show thread IDs
-        .with_thread_names(false) // Don't show thread names
-        .with_file(false) // Don't show file names
-        .with_line_number(false) // Don't show line numbers
         .without_time() // Don't show timestamps
         .init(); // Initialize the subscriber
 
     if let Err(e) = run() {
-        // Now this will actually print
         error!("{}", e);
         std::process::exit(1);
     }

--- a/zparse/src/parser/config.rs
+++ b/zparse/src/parser/config.rs
@@ -1,4 +1,4 @@
-use crate::error::{ParseError, ParseErrorKind, Result};
+use crate::error::{ParseError, ParseErrorKind, Result, SecurityError};
 
 /// Maximum nesting depth (32) based on common JSON/TOML usage patterns
 pub const DEFAULT_MAX_DEPTH: usize = 32;
@@ -44,7 +44,7 @@ impl ParserConfig {
     pub fn validate_string(&self, s: &str) -> Result<()> {
         if s.len() > self.max_string_length {
             return Err(ParseError::new(ParseErrorKind::Security(
-                crate::error::SecurityError::MaxStringLengthExceeded,
+                SecurityError::MaxStringLengthExceeded,
             )));
         }
         Ok(())
@@ -53,7 +53,7 @@ impl ParserConfig {
     pub fn validate_object_entries(&self, count: usize) -> Result<()> {
         if count > self.max_object_entries {
             return Err(ParseError::new(ParseErrorKind::Security(
-                crate::error::SecurityError::MaxObjectEntriesExceeded,
+                SecurityError::MaxObjectEntriesExceeded,
             )));
         }
         Ok(())
@@ -78,7 +78,7 @@ impl ParsingContext {
         self.current_depth += 1;
         if self.current_depth > config.max_depth {
             return Err(ParseError::new(ParseErrorKind::Security(
-                crate::error::SecurityError::MaxDepthExceeded,
+                SecurityError::MaxDepthExceeded,
             )));
         }
         Ok(())
@@ -94,7 +94,7 @@ impl ParsingContext {
         self.current_size += size;
         if self.current_size > config.max_size {
             return Err(ParseError::new(ParseErrorKind::Security(
-                crate::error::SecurityError::MaxSizeExceeded,
+                SecurityError::MaxSizeExceeded,
             )));
         }
         Ok(())

--- a/zparse/src/parser/json.rs
+++ b/zparse/src/parser/json.rs
@@ -7,14 +7,17 @@
 //! - Provides detailed error messages
 //! - Handles nested structures with proper depth checking
 
-use super::config::ParserConfig;
-use crate::common::parser_state::ParserState;
-use crate::enums::Token;
-use crate::error::{
-    LexicalError, Location, ParseError, ParseErrorKind, Result, SemanticError, SyntaxError,
-};
-use crate::parser::{lexer::Lexer, value::Value};
 use std::collections::HashMap;
+
+use super::config::ParserConfig;
+use crate::{
+    common::parser_state::ParserState,
+    enums::Token,
+    error::{
+        LexicalError, Location, ParseError, ParseErrorKind, Result, SemanticError, SyntaxError,
+    },
+    parser::{lexer::Lexer, value::Value},
+};
 
 #[derive(Debug)]
 pub struct JsonParser {

--- a/zparse/src/parser/json.rs
+++ b/zparse/src/parser/json.rs
@@ -10,7 +10,9 @@
 use super::config::ParserConfig;
 use crate::common::parser_state::ParserState;
 use crate::enums::Token;
-use crate::error::{LexicalError, ParseError, ParseErrorKind, Result, SemanticError, SyntaxError};
+use crate::error::{
+    LexicalError, Location, ParseError, ParseErrorKind, Result, SemanticError, SyntaxError,
+};
 use crate::parser::{lexer::Lexer, value::Value};
 use std::collections::HashMap;
 
@@ -50,21 +52,7 @@ impl JsonParser {
     }
 
     fn create_error(&self, kind: ParseErrorKind, context: &str) -> ParseError {
-        // Get current location
-        let (line, column) = self.lexer.get_location();
-
-        // Create base error
-        let mut error = ParseError::new(kind);
-
-        // Add location
-        error = error.with_location(line, column);
-
-        // Only add context if it provides additional info
-        if !context.is_empty() {
-            error = error.with_context(context);
-        }
-
-        error
+        Location::from_lexer(&self.lexer).create_error(kind, context)
     }
 
     /// Setter method to configure the parser

--- a/zparse/src/parser/lexer.rs
+++ b/zparse/src/parser/lexer.rs
@@ -9,9 +9,11 @@ pub mod string_parser;
 use number_parser::read_number;
 use string_parser::read_string;
 
-use crate::enums::Token;
-use crate::error::{LexicalError, ParseError, ParseErrorKind, Result, SyntaxError};
-use crate::parser::config::ParserConfig;
+use crate::{
+    enums::Token,
+    error::{LexicalError, ParseError, ParseErrorKind, Result, SyntaxError},
+    parser::config::ParserConfig,
+};
 
 /// The core Lexer struct that other modules will use
 #[derive(Debug)]

--- a/zparse/src/parser/lexer.rs
+++ b/zparse/src/parser/lexer.rs
@@ -26,6 +26,9 @@ pub struct Lexer {
     pub(crate) is_json_mode: bool,
     /// Configuration for the parser
     pub(crate) config: ParserConfig,
+    /// Location tracking for error messages
+    pub(crate) line: usize,
+    pub(crate) column: usize,
 }
 
 impl Lexer {
@@ -39,6 +42,8 @@ impl Lexer {
             current_char,
             is_json_mode: false,
             config: ParserConfig::default(),
+            line: 1,
+            column: 1,
         }
     }
 
@@ -50,96 +55,126 @@ impl Lexer {
     }
 
     /// Moves to the next character in the input
-    pub(crate) fn advance(&mut self) {
+    pub fn advance(&mut self) {
+        if let Some(c) = self.current_char {
+            if c == '\n' {
+                self.line += 1;
+                self.column = 1;
+            } else {
+                self.column += 1;
+            }
+        }
         self.position += 1;
         self.current_char = self.input.get(self.position).copied();
     }
 
-    /// Skips whitespace characters in the input
-    fn skip_whitespace(&mut self) {
+    fn skip_comment(&mut self) {
         while let Some(c) = self.current_char {
-            if !c.is_whitespace() {
+            if c == '\n' {
+                self.advance();
                 break;
             }
             self.advance();
         }
     }
 
+    /// Skips whitespace characters in the input
+    fn skip_whitespace(&mut self) {
+        while let Some(c) = self.current_char {
+            if c == '#' {
+                self.skip_comment();
+            } else if !c.is_whitespace() {
+                break;
+            }
+            self.advance();
+        }
+    }
+
+    /// Helper method to get current location
+    pub fn get_location(&self) -> (usize, usize) {
+        (self.line, self.column)
+    }
+
     /// Produces the next token from the input
     pub fn next_token(&mut self) -> Result<Token> {
         self.skip_whitespace();
 
-        match self.current_char {
+        let token = match self.current_char {
             None => Ok(Token::EOF),
-            Some(c) => match c {
-                '{' => {
-                    self.advance();
-                    Ok(Token::LeftBrace)
-                }
-                '}' => {
-                    self.advance();
-                    Ok(Token::RightBrace)
-                }
-                '[' => {
-                    self.advance();
-                    Ok(Token::LeftBracket)
-                }
-                ']' => {
-                    self.advance();
-                    Ok(Token::RightBracket)
-                }
-                ':' => {
-                    self.advance();
-                    Ok(Token::Colon)
-                }
-                ',' => {
-                    self.advance();
-                    Ok(Token::Comma)
-                }
-                '=' => {
-                    self.advance();
-                    Ok(Token::Equals)
-                }
-                '.' => {
-                    self.advance();
-                    Ok(Token::Dot)
-                }
-                '"' => {
-                    // Route to dedicated string parsing
-                    let s = read_string(self)?;
-                    Ok(Token::String(s))
-                }
-                '0'..='9' | '-' | '_' => {
-                    // Route to dedicated number parsing
-                    let n = read_number(self)?;
-                    Ok(Token::Number(n))
-                }
-                't' => self.read_true_or_identifier(),
-                'f' => self.read_false_or_identifier(),
-                'n' => self.read_null_or_identifier(),
-                _ if Self::is_bare_key_start(c) => {
-                    // In JSON mode, we forbid bare keys
-                    if self.is_json_mode {
-                        Err(ParseError::new(ParseErrorKind::Lexical(
-                            LexicalError::InvalidToken(format!(
-                                "Unexpected char '{}'. JSON requires quoted strings",
-                                c
-                            )),
-                        )))
-                    } else {
-                        // Parse a bare key
-                        let s = self.read_bare_key()?;
+            Some(c) => {
+                let (line, column) = (self.line, self.column);
+                match c {
+                    '{' => {
+                        self.advance();
+                        Ok(Token::LeftBrace)
+                    }
+                    '}' => {
+                        self.advance();
+                        Ok(Token::RightBrace)
+                    }
+                    '[' => {
+                        self.advance();
+                        Ok(Token::LeftBracket)
+                    }
+                    ']' => {
+                        self.advance();
+                        Ok(Token::RightBracket)
+                    }
+                    ':' => {
+                        self.advance();
+                        Ok(Token::Colon)
+                    }
+                    ',' => {
+                        self.advance();
+                        Ok(Token::Comma)
+                    }
+                    '=' => {
+                        self.advance();
+                        Ok(Token::Equals)
+                    }
+                    '.' => {
+                        self.advance();
+                        Ok(Token::Dot)
+                    }
+                    '"' => {
+                        // Route to dedicated string parsing
+                        let s = read_string(self)?;
                         Ok(Token::String(s))
                     }
+                    '0'..='9' | '-' | '_' => {
+                        // Route to dedicated number parsing
+                        let n = read_number(self)?;
+                        Ok(Token::Number(n))
+                    }
+                    't' => self.read_true_or_identifier(),
+                    'f' => self.read_false_or_identifier(),
+                    'n' => self.read_null_or_identifier(),
+                    _ if Self::is_bare_key_start(c) => {
+                        if self.is_json_mode {
+                            Err(ParseError::new(ParseErrorKind::Lexical(
+                                LexicalError::InvalidToken(format!(
+                                    "Unexpected char '{}'. JSON requires quoted strings",
+                                    c
+                                )),
+                            ))
+                            .with_location(line, column))
+                        } else {
+                            // Parse a bare key
+                            let s = self.read_bare_key()?;
+                            Ok(Token::String(s))
+                        }
+                    }
+                    _ => Err(
+                        ParseError::new(ParseErrorKind::Lexical(LexicalError::InvalidToken(
+                            format!("Unexpected character '{}' at position {}", c, self.position),
+                        )))
+                        .with_location(line, column),
+                    ),
                 }
-                _ => Err(ParseError::new(ParseErrorKind::Lexical(
-                    LexicalError::InvalidToken(format!(
-                        "Unexpected character '{}' at position {}",
-                        c, self.position
-                    )),
-                ))),
-            },
-        }
+            }
+        }?;
+
+        Ok(token)
     }
 
     fn is_bare_key_start(c: char) -> bool {

--- a/zparse/src/parser/lexer/string_parser.rs
+++ b/zparse/src/parser/lexer/string_parser.rs
@@ -53,10 +53,10 @@ pub(crate) fn read_string(lexer: &mut Lexer) -> Result<String> {
         }
     }
 
-    // If we exit the while loop, we ran out of characters before finding a closing quote
-    Err(ParseError::new(ParseErrorKind::Lexical(
-        LexicalError::UnexpectedEOF,
-    )))
+    let err = ParseError::new(ParseErrorKind::Lexical(LexicalError::UnterminatedString))
+        .with_location(lexer.line, lexer.column);
+
+    Err(err)
 }
 
 fn parse_unicode_escape(lexer: &mut Lexer) -> Result<String> {

--- a/zparse/src/parser/toml.rs
+++ b/zparse/src/parser/toml.rs
@@ -6,7 +6,8 @@ use super::{
 use crate::common::parser_state::ParserState;
 use crate::enums::Token;
 use crate::error::{
-    LexicalError, ParseError, ParseErrorKind, Result, SecurityError, SemanticError, SyntaxError,
+    LexicalError, Location, ParseError, ParseErrorKind, Result, SecurityError, SemanticError,
+    SyntaxError,
 };
 use std::collections::HashMap;
 
@@ -48,21 +49,7 @@ impl TomlParser {
     }
 
     fn create_error(&self, kind: ParseErrorKind, context: &str) -> ParseError {
-        // Get current location
-        let (line, column) = self.lexer.get_location();
-
-        // Create base error
-        let mut error = ParseError::new(kind);
-
-        // Add location
-        error = error.with_location(line, column);
-
-        // Only add context if it provides additional info
-        if !context.is_empty() {
-            error = error.with_context(context);
-        }
-
-        error
+        Location::from_lexer(&self.lexer).create_error(kind, context)
     }
 
     /// Setter method to configure the parser

--- a/zparse/src/parser/toml.rs
+++ b/zparse/src/parser/toml.rs
@@ -1,15 +1,18 @@
+use std::collections::HashMap;
+
 use super::{
     config::{ParserConfig, ParsingContext},
     lexer::Lexer,
     value::Value,
 };
-use crate::common::parser_state::ParserState;
-use crate::enums::Token;
-use crate::error::{
-    LexicalError, Location, ParseError, ParseErrorKind, Result, SecurityError, SemanticError,
-    SyntaxError,
+use crate::{
+    common::parser_state::ParserState,
+    enums::Token,
+    error::{
+        LexicalError, Location, ParseError, ParseErrorKind, Result, SecurityError, SemanticError,
+        SyntaxError,
+    },
 };
-use std::collections::HashMap;
 
 #[derive(Debug)]
 pub struct TomlParser {

--- a/zparse/src/parser/toml.rs
+++ b/zparse/src/parser/toml.rs
@@ -47,6 +47,24 @@ impl TomlParser {
         })
     }
 
+    fn create_error(&self, kind: ParseErrorKind, context: &str) -> ParseError {
+        // Get current location
+        let (line, column) = self.lexer.get_location();
+
+        // Create base error
+        let mut error = ParseError::new(kind);
+
+        // Add location
+        error = error.with_location(line, column);
+
+        // Only add context if it provides additional info
+        if !context.is_empty() {
+            error = error.with_context(context);
+        }
+
+        error
+    }
+
     /// Setter method to configure the parser
     pub fn with_config(mut self, config: ParserConfig) -> Self {
         self.config = config;
@@ -69,9 +87,13 @@ impl TomlParser {
                 }
                 Token::EOF => break,
                 _ => {
-                    return Err(ParseError::new(ParseErrorKind::Lexical(
-                        LexicalError::UnexpectedToken(format!("{:?}", self.current_token)),
-                    )));
+                    return Err(self.create_error(
+                        ParseErrorKind::Lexical(LexicalError::UnexpectedToken(format!(
+                            "{:?}",
+                            self.current_token
+                        ))),
+                        "Expected table header or key-value pair at root level",
+                    ));
                 }
             }
         }
@@ -94,9 +116,10 @@ impl TomlParser {
 
         // Check max depth before processing
         if self.context.current_depth >= self.config.max_depth {
-            return Err(ParseError::new(ParseErrorKind::Security(
-                SecurityError::MaxDepthExceeded,
-            )));
+            return Err(self.create_error(
+                ParseErrorKind::Security(SecurityError::MaxDepthExceeded),
+                "Maximum depth for nested tables exceeded",
+            ));
         }
 
         loop {
@@ -104,9 +127,10 @@ impl TomlParser {
                 Token::String(s) => {
                     // Check max depth on each new component
                     if path.len() >= self.config.max_depth {
-                        return Err(ParseError::new(ParseErrorKind::Security(
-                            SecurityError::MaxDepthExceeded,
-                        )));
+                        return Err(self.create_error(
+                            ParseErrorKind::Security(SecurityError::MaxDepthExceeded),
+                            "Maximum depth for nested tables exceeded",
+                        ));
                     }
 
                     // Validate string length and track memory
@@ -128,12 +152,13 @@ impl TomlParser {
                     self.advance()?;
                     if is_array_table {
                         if self.current_token != Token::RightBracket {
-                            return Err(ParseError::new(ParseErrorKind::Lexical(
-                                LexicalError::UnexpectedToken(format!(
+                            return Err(self.create_error(
+                                ParseErrorKind::Lexical(LexicalError::UnexpectedToken(format!(
                                     "{:?}. Expected ] for array table",
                                     self.current_token,
-                                )),
-                            )));
+                                ))),
+                                "Expected closing ']]' for array table",
+                            ));
                         }
                         self.advance()?; // consume second ']'
                         self.detect_circular_reference(&path)?;
@@ -147,12 +172,13 @@ impl TomlParser {
                     break;
                 }
                 _ => {
-                    return Err(ParseError::new(ParseErrorKind::Lexical(
-                        LexicalError::UnexpectedToken(format!(
-                            "{:?}. Invalid table header",
+                    return Err(self.create_error(
+                        ParseErrorKind::Lexical(LexicalError::UnexpectedToken(format!(
+                            "{:?}",
                             self.current_token
-                        )),
-                    )))
+                        ))),
+                        "Invalid table header: expected string or dot",
+                    ))
                 }
             }
         }
@@ -162,64 +188,72 @@ impl TomlParser {
     }
 
     fn ensure_table_exists(&mut self) -> Result<()> {
+        // Check total depth before processing
+        if self.current_table.len() > self.config.max_depth {
+            return Err(self.create_error(
+                ParseErrorKind::Security(SecurityError::MaxDepthExceeded),
+                "Maximum depth for nested tables exceeded",
+            ));
+        }
+
         let mut current = &mut self.tables;
         let mut path = Vec::new();
 
-        // Check total depth before processing
-        if self.current_table.len() > self.config.max_depth {
-            return Err(ParseError::new(ParseErrorKind::Security(
-                SecurityError::MaxDepthExceeded,
-            )));
-        }
-
         for key in &self.current_table {
-            // Track nesting level
             self.context.enter_nested(&self.config)?;
             path.push(key);
 
-            // First check if the key exists and if it's a non-table type
+            // Clone the values we need for error messages
             if let Some(existing) = current.get(key) {
-                match existing {
+                let error = match existing {
                     Value::Map(_) => {
-                        // If this is the final component and it already exists as a table
                         if path.len() == self.current_table.len() {
-                            return Err(ParseError::new(ParseErrorKind::Syntax(
-                                SyntaxError::InvalidValue(format!(
+                            let path_str = path
+                                .iter()
+                                .map(|s| s.as_str())
+                                .collect::<Vec<_>>()
+                                .join(".");
+                            Some((
+                                ParseErrorKind::Syntax(SyntaxError::InvalidValue(format!(
                                     "Duplicate table definition: [{}]",
-                                    path.iter()
-                                        .map(|s| s.as_str())
-                                        .collect::<Vec<_>>()
-                                        .join(".")
-                                )),
-                            )));
+                                    path_str
+                                ))),
+                                "Table has already been defined",
+                            ))
+                        } else {
+                            None
                         }
                     }
-                    Value::Array(_) => {
-                        return Err(ParseError::new(ParseErrorKind::Semantic(
-                            SemanticError::NestedTableError,
-                        )))
-                    }
+                    Value::Array(_) => Some((
+                        ParseErrorKind::Semantic(SemanticError::NestedTableError),
+                        "Cannot redefine array table as regular table",
+                    )),
                     Value::Number(n) => {
-                        return Err(ParseError::new(ParseErrorKind::Semantic(
-                            SemanticError::TypeMismatch(format!(
+                        let msg = if n.fract() == 0.0 {
+                            n.trunc().to_string()
+                        } else {
+                            n.to_string()
+                        };
+                        Some((
+                            ParseErrorKind::Semantic(SemanticError::TypeMismatch(format!(
                                 "Expected table, found Number({})",
-                                // Format number without decimal point if it's a whole number
-                                if n.fract() == 0.0 {
-                                    n.trunc().to_string()
-                                } else {
-                                    n.to_string()
-                                }
-                            )),
-                        )));
+                                msg
+                            ))),
+                            "Cannot use a number where a table is expected",
+                        ))
                     }
-                    other => {
-                        return Err(ParseError::new(ParseErrorKind::Semantic(
-                            SemanticError::TypeMismatch(format!(
-                                "Expected table, found {:?}",
-                                other
-                            )),
-                        )))
-                    }
+                    other => Some((
+                        ParseErrorKind::Semantic(SemanticError::TypeMismatch(format!(
+                            "Expected table, found {:?}",
+                            other
+                        ))),
+                        "Invalid value type for table",
+                    )),
+                };
+
+                // If we have an error, return it
+                if let Some((kind, context)) = error {
+                    return Err(self.create_error(kind, context));
                 }
             }
 
@@ -232,17 +266,17 @@ impl TomlParser {
                     match entry.get_mut() {
                         Value::Map(_) => {} // OK - continue traversing
                         Value::Array(_) => {
-                            return Err(ParseError::new(ParseErrorKind::Semantic(
-                                SemanticError::NestedTableError,
-                            )))
+                            return Err(self.create_error(
+                                ParseErrorKind::Semantic(SemanticError::NestedTableError),
+                                "Cannot redefine array table as regular table",
+                            ))
                         }
                         other => {
-                            return Err(ParseError::new(ParseErrorKind::Semantic(
-                                SemanticError::TypeMismatch(format!(
-                                    "Expected table, found {:?}",
-                                    other
-                                )),
-                            )))
+                            let error_msg = format!("Expected table, found {:?}", other);
+                            return Err(self.create_error(
+                                ParseErrorKind::Semantic(SemanticError::TypeMismatch(error_msg)),
+                                "Cannot use a number where a table is expected",
+                            ));
                         }
                     }
                 }
@@ -251,9 +285,10 @@ impl TomlParser {
             current = match current.get_mut(key) {
                 Some(Value::Map(table)) => table,
                 _ => {
-                    return Err(ParseError::new(ParseErrorKind::Semantic(
-                        SemanticError::NestedTableError,
-                    )))
+                    return Err(self.create_error(
+                        ParseErrorKind::Semantic(SemanticError::NestedTableError),
+                        "Cannot redefine array table as regular table",
+                    ))
                 }
             };
 
@@ -277,20 +312,25 @@ impl TomlParser {
                 s.clone()
             }
             _ => {
-                return Err(ParseError::new(ParseErrorKind::Lexical(
-                    LexicalError::UnexpectedToken(format!(
-                        "{:?}. Expected key.",
+                return Err(self.create_error(
+                    ParseErrorKind::Lexical(LexicalError::UnexpectedToken(format!(
+                        "{:?}",
                         self.current_token
-                    )),
-                )))
+                    ))),
+                    "Expected a valid TOML key",
+                ))
             }
         };
         self.advance()?;
 
         if self.current_token != Token::Equals {
-            return Err(ParseError::new(ParseErrorKind::Lexical(
-                LexicalError::UnexpectedToken(format!("{:?}. Expected =", self.current_token)),
-            )));
+            return Err(self.create_error(
+                ParseErrorKind::Lexical(LexicalError::UnexpectedToken(format!(
+                    "{:?}",
+                    self.current_token
+                ))),
+                "Expected '=' after key in key-value pair",
+            ));
         }
         self.advance()?;
 
@@ -305,15 +345,17 @@ impl TomlParser {
                     if let Some(Value::Map(table)) = arr.last_mut() {
                         table
                     } else {
-                        return Err(ParseError::new(ParseErrorKind::Semantic(
-                            SemanticError::NestedTableError,
-                        )));
+                        return Err(self.create_error(
+                            ParseErrorKind::Semantic(SemanticError::NestedTableError),
+                            "Cannot redefine array table as regular table",
+                        ));
                     }
                 }
                 _ => {
-                    return Err(ParseError::new(ParseErrorKind::Semantic(
-                        SemanticError::NestedTableError,
-                    )))
+                    return Err(self.create_error(
+                        ParseErrorKind::Semantic(SemanticError::NestedTableError),
+                        "Cannot redefine array table as regular table",
+                    ));
                 }
             };
         }
@@ -347,9 +389,14 @@ impl TomlParser {
             }
             Token::LeftBracket => self.parse_array(),
             Token::LeftBrace => self.parse_inline_table(),
-            _ => Err(ParseError::new(ParseErrorKind::Lexical(
-                LexicalError::UnexpectedToken(format!("{:?}", self.current_token)),
-            ))),
+            _ => Err(self.create_error(
+                            ParseErrorKind::Lexical(LexicalError::UnexpectedToken(format!(
+                                "{:?}",
+                                self.current_token
+                            ))),
+                            "Expected a valid TOML value (string, number, boolean, datetime, array, or inline table)",
+                        ))
+
         }
     }
 
@@ -372,27 +419,28 @@ impl TomlParser {
                 Token::Comma => {
                     self.advance()?;
                     if self.current_token == Token::RightBracket {
-                        return Err(ParseError::new(ParseErrorKind::Syntax(
-                            SyntaxError::InvalidValue(format!(
-                                "Trailing comma in {:?}",
-                                self.current_token
+                        return Err(self.create_error(
+                            ParseErrorKind::Syntax(SyntaxError::InvalidValue(
+                                "Trailing comma in array".to_string(),
                             )),
-                        )));
+                            "TOML arrays cannot end with a trailing comma",
+                        ));
                     }
                 }
                 Token::RightBracket => break,
                 _ => {
-                    return Err(ParseError::new(ParseErrorKind::Lexical(
-                        LexicalError::UnexpectedToken(format!(
-                            "{:?}. Expected , or ]",
+                    return Err(self.create_error(
+                        ParseErrorKind::Lexical(LexicalError::UnexpectedToken(format!(
+                            "{:?}",
                             self.current_token
-                        )),
-                    )))
+                        ))),
+                        "Expected ',' between array elements or ']' to close array",
+                    ));
                 }
             }
         }
 
-        self.advance()?; // consume ']'
+        self.advance()?;
         self.context.exit_nested();
         Ok(Value::Array(array))
     }
@@ -425,20 +473,25 @@ impl TomlParser {
                     s.clone()
                 }
                 _ => {
-                    return Err(ParseError::new(ParseErrorKind::Lexical(
-                        LexicalError::UnexpectedToken(format!(
-                            "{:?}. Expected key.",
+                    return Err(self.create_error(
+                        ParseErrorKind::Lexical(LexicalError::UnexpectedToken(format!(
+                            "{:?}",
                             self.current_token
-                        )),
-                    )))
+                        ))),
+                        "Expected a valid TOML key",
+                    ))
                 }
             };
             self.advance()?;
 
             if self.current_token != Token::Equals {
-                return Err(ParseError::new(ParseErrorKind::Lexical(
-                    LexicalError::UnexpectedToken(format!("{:?}. Expected =", self.current_token)),
-                )));
+                return Err(self.create_error(
+                    ParseErrorKind::Lexical(LexicalError::UnexpectedToken(format!(
+                        "{:?}",
+                        self.current_token
+                    ))),
+                    "Expected '=' after key in key-value pair",
+                ));
             }
             self.advance()?;
 
@@ -454,12 +507,13 @@ impl TomlParser {
                     break;
                 }
                 _ => {
-                    return Err(ParseError::new(ParseErrorKind::Lexical(
-                        LexicalError::UnexpectedToken(format!(
-                            "{:?}. Expected , or }}",
+                    return Err(self.create_error(
+                        ParseErrorKind::Lexical(LexicalError::UnexpectedToken(format!(
+                            "{:?}",
                             self.current_token
-                        )),
-                    )))
+                        ))),
+                        "Expected ',' between array elements or '}}' to close array",
+                    ));
                 }
             }
         }
@@ -500,9 +554,10 @@ impl TomlParser {
                             arr.push(Value::Map(HashMap::new()));
                         }
                         _ => {
-                            return Err(ParseError::new(ParseErrorKind::Semantic(
-                                SemanticError::NestedTableError,
-                            )))
+                            return Err(self.create_error(
+                                ParseErrorKind::Semantic(SemanticError::NestedTableError),
+                                "Cannot redefine array table as regular table",
+                            ))
                         }
                     }
                 }
@@ -515,15 +570,17 @@ impl TomlParser {
                     if let Some(Value::Map(table)) = arr.last_mut() {
                         table
                     } else {
-                        return Err(ParseError::new(ParseErrorKind::Semantic(
-                            SemanticError::NestedTableError,
-                        )));
+                        return Err(self.create_error(
+                            ParseErrorKind::Semantic(SemanticError::NestedTableError),
+                            "Cannot redefine array table as regular table",
+                        ));
                     }
                 }
                 _ => {
-                    return Err(ParseError::new(ParseErrorKind::Semantic(
-                        SemanticError::NestedTableError,
-                    )))
+                    return Err(self.create_error(
+                        ParseErrorKind::Semantic(SemanticError::NestedTableError),
+                        "Cannot redefine array table as regular table",
+                    ));
                 }
             };
 
@@ -535,39 +592,15 @@ impl TomlParser {
     }
 
     fn detect_circular_reference(&self, path: &[String]) -> Result<()> {
-        let full_path = path.join(".");
-        let mut current_path = String::new();
-
-        for segment in path {
-            if !current_path.is_empty() {
-                current_path.push('.');
-            }
-            current_path.push_str(segment);
-
-            // Check if this path exists and references the target path
-            if let Some(Value::Map(table)) = self.tables.get(&current_path) {
-                if contains_path(table, &full_path) {
-                    return Err(ParseError::new(ParseErrorKind::Semantic(
-                        SemanticError::CircularReference,
-                    )));
-                }
+        let mut seen = std::collections::HashSet::new();
+        for key in path {
+            if !seen.insert(key) {
+                return Err(self.create_error(
+                    ParseErrorKind::Semantic(SemanticError::CircularReference),
+                    "Circular table reference detected in TOML document",
+                ));
             }
         }
         Ok(())
     }
-}
-
-fn contains_path(table: &HashMap<String, Value>, target_path: &str) -> bool {
-    for (key, value) in table {
-        match value {
-            Value::Map(inner_table) => {
-                let current_path = format!("{}.{}", target_path, key);
-                if current_path == target_path || contains_path(inner_table, target_path) {
-                    return true;
-                }
-            }
-            _ => continue,
-        }
-    }
-    false
 }

--- a/zparse/src/test_utils.rs
+++ b/zparse/src/test_utils.rs
@@ -13,8 +13,10 @@ pub use crate::{
     common::value_compare::values_equal,
     converter::Converter,
     error::{
-        LexicalError, ParseError, ParseErrorKind, Result, SecurityError, SemanticError, SyntaxError,
+        FormatError, LexicalError, ParseError, ParseErrorKind, Result, SecurityError,
+        SemanticError, SyntaxError,
     },
+    formatter::{FormatConfig, Formatter, JsonFormatter},
     parse_file,
     parser::{config::ParserConfig, JsonParser, TomlParser, Value},
     utils::{format_json, format_toml, parse_json, parse_toml, read_file, write_file},

--- a/zparse/src/test_utils.rs
+++ b/zparse/src/test_utils.rs
@@ -18,6 +18,9 @@ pub use crate::{
     },
     formatter::{FormatConfig, Formatter, JsonFormatter},
     parse_file,
-    parser::{config::ParserConfig, JsonParser, TomlParser, Value},
+    parser::{
+        config::{ParserConfig, DEFAULT_MAX_DEPTH, DEFAULT_MAX_OBJECT_ENTRIES, DEFAULT_MAX_SIZE},
+        JsonParser, TomlParser, Value,
+    },
     utils::{format_json, format_toml, parse_json, parse_toml, read_file, write_file},
 };

--- a/zparse/src/test_utils/data.rs
+++ b/zparse/src/test_utils/data.rs
@@ -1,5 +1,6 @@
-use crate::error::{IOError, ParseError, ParseErrorKind, Result};
 use std::fs;
+
+use crate::error::{IOError, ParseError, ParseErrorKind, Result};
 
 pub struct TestData {
     pub small_json: String,

--- a/zparse/src/test_utils/helpers.rs
+++ b/zparse/src/test_utils/helpers.rs
@@ -1,7 +1,8 @@
-use crate::error::{IOError, ParseError, ParseErrorKind, Result};
 use std::env;
 use std::fs;
 use std::path::PathBuf;
+
+use crate::error::{IOError, ParseError, ParseErrorKind, Result};
 
 pub fn tmp_file_path(name: &str) -> PathBuf {
     let mut dir = env::temp_dir();

--- a/zparse/src/utils.rs
+++ b/zparse/src/utils.rs
@@ -36,10 +36,10 @@ pub fn parse_toml(content: &str) -> Result<Value> {
     parser.parse()
 }
 
-pub fn format_json(value: &Value) -> String {
+pub fn format_json(value: &Value) -> Result<String> {
     JsonFormatter.format(value, &FormatConfig::default())
 }
 
-pub fn format_toml(value: &Value) -> String {
+pub fn format_toml(value: &Value) -> Result<String> {
     TomlFormatter.format(value, &FormatConfig::default())
 }

--- a/zparse/src/utils.rs
+++ b/zparse/src/utils.rs
@@ -1,9 +1,10 @@
+use std::fs;
+
 use crate::{
     error::{IOError, ParseError, ParseErrorKind, Result},
     formatter::{FormatConfig, Formatter, JsonFormatter, TomlFormatter},
     parser::{json::JsonParser, toml::TomlParser, value::Value},
 };
-use std::fs;
 
 pub fn read_file(path: &str) -> Result<String> {
     fs::read_to_string(path).map_err(|e| match e.kind() {

--- a/zparse/tests/io_tests.rs
+++ b/zparse/tests/io_tests.rs
@@ -59,7 +59,7 @@ fn parse_and_format_json_file() {
     // Use parse_file to parse the JSON file.
     let parsed = parse_file(temp_path_str).expect("Failed to parse JSON file");
     // Format back using the JSON formatter.
-    let formatted = format_json(&parsed);
+    let formatted = format_json(&parsed).expect("Failed to format JSON");
     // Check that the formatted output contains at least one expected element.
     assert!(
         formatted.contains("\"key\""),
@@ -90,7 +90,7 @@ fn parse_and_format_toml_file() {
     // Use parse_file to parse the TOML file.
     let parsed = parse_file(temp_path_str).expect("Failed to parse TOML file");
     // Format using the TOML formatter.
-    let formatted = format_toml(&parsed);
+    let formatted = format_toml(&parsed).expect("Failed to format TOML");
     // Check that the formatted output contains expected key names.
     assert!(
         formatted.contains("key"),

--- a/zparse/tests/json_tests.rs
+++ b/zparse/tests/json_tests.rs
@@ -366,4 +366,27 @@ mod json_tests {
             panic!("Expected error location information");
         }
     }
+
+    #[test]
+    fn test_json_formatter_errors() {
+        let formatter = JsonFormatter;
+        let config = FormatConfig {
+            indent_spaces: 100, // Invalid indentation
+            sort_keys: true,
+        };
+
+        let mut map = HashMap::new();
+        map.insert("key".to_string(), Value::String("value".to_string()));
+        let value = Value::Map(map);
+
+        let result = formatter.format(&value, &config);
+
+        assert!(result.is_err(), "Expected error for invalid indentation");
+        if let Err(e) = result {
+            match e.kind() {
+                ParseErrorKind::Format(FormatError::InvalidIndentation(_)) => {}
+                other => panic!("Expected InvalidIndentation error, got {:?}", other),
+            }
+        }
+    }
 }

--- a/zparse/tests/json_tests.rs
+++ b/zparse/tests/json_tests.rs
@@ -5,7 +5,7 @@
 #[cfg(test)]
 mod json_tests {
     use std::collections::HashMap;
-    
+
     use zparse::test_utils::*;
 
     // Basic Parsing Tests

--- a/zparse/tests/json_tests.rs
+++ b/zparse/tests/json_tests.rs
@@ -5,6 +5,7 @@
 #[cfg(test)]
 mod json_tests {
     use std::collections::HashMap;
+    
     use zparse::test_utils::*;
 
     // Basic Parsing Tests

--- a/zparse/tests/json_tests.rs
+++ b/zparse/tests/json_tests.rs
@@ -209,6 +209,31 @@ mod json_tests {
 
     // Error Cases
     #[test]
+    fn test_invalid_unicode_sequence() {
+        let input = r#"{"key": "\u123Z"}"#;
+        let result = parse_json(input);
+        assert!(result.is_err());
+        match result.unwrap_err().kind() {
+            ParseErrorKind::Lexical(LexicalError::InvalidUnicode) => {}
+            other => panic!("Expected InvalidUnicode error, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_circular_reference_detection() {
+        let input = r#"{
+            "a": {"b": {"c": {"d": "circular"}}}
+        }"#;
+        let result = parse_json(input);
+        if result.is_err() {
+            match result.unwrap_err().kind() {
+                ParseErrorKind::Security(SecurityError::MaxDepthExceeded) => {}
+                other => panic!("Expected MaxDepthExceeded error, got {:?}", other),
+            }
+        }
+    }
+
+    #[test]
     fn test_invalid_json() {
         let invalid_inputs = vec![
             ("{", "Incomplete object"),
@@ -318,6 +343,27 @@ mod json_tests {
                 "Expected LexicalError::InvalidToken due to unquoted value, got {:?}",
                 other
             ),
+        }
+    }
+
+    #[test]
+    fn test_error_location_info() {
+        let input = "{\n  \"key\": \n  invalid\n}";
+        let result = parse_json(input);
+        assert!(result.is_err());
+
+        let err = result.unwrap_err();
+        println!("Error: {:?}", err);
+
+        if let Some(location) = err.location() {
+            println!(
+                "Location - line: {}, column: {}",
+                location.line, location.column
+            );
+            assert_eq!(location.line, 3, "Expected error on line 3");
+            assert_eq!(location.column, 3, "Expected error at column 3");
+        } else {
+            panic!("Expected error location information");
         }
     }
 }

--- a/zparse/tests/property_tests.rs
+++ b/zparse/tests/property_tests.rs
@@ -1,41 +1,10 @@
 #![allow(clippy::unwrap_used)]
 #![allow(clippy::as_conversions)]
+#![allow(clippy::panic)]
 
 use proptest::collection::vec;
 use proptest::prelude::*;
-use zparse::{
-    parser::{config::ParserConfig, JsonParser, Value},
-    Converter,
-};
-
-// Helper function to compare values structurally rather than string representation
-fn values_equal(left: &Value, right: &Value) -> bool {
-    match (left, right) {
-        (Value::Map(l_map), Value::Map(r_map)) => {
-            if l_map.len() != r_map.len() {
-                return false;
-            }
-            l_map
-                .iter()
-                .all(|(k, v)| r_map.get(k).is_some_and(|r_v| values_equal(v, r_v)))
-        }
-        (Value::Array(l_arr), Value::Array(r_arr)) => {
-            if l_arr.len() != r_arr.len() {
-                return false;
-            }
-            l_arr
-                .iter()
-                .zip(r_arr.iter())
-                .all(|(l, r)| values_equal(l, r))
-        }
-        (Value::Number(l), Value::Number(r)) => (l - r).abs() < f64::EPSILON,
-        (Value::String(l), Value::String(r)) => l == r,
-        (Value::Boolean(l), Value::Boolean(r)) => l == r,
-        (Value::Null, Value::Null) => true,
-        (Value::DateTime(l), Value::DateTime(r)) => l == r,
-        _ => false,
-    }
-}
+use zparse::test_utils::*;
 
 // Strategy for generating valid JSON strings
 fn json_string_strategy() -> impl Strategy<Value = String> {
@@ -51,19 +20,18 @@ proptest! {
     // Basic Tests
     #[test]
     fn test_basic_json_roundtrip(s in json_string_strategy()) {
-            let json_str = format!(
-                r#"{{"string":"{}","number":42.5,"boolean":true,"array":[1,2,3]}}"#,
-                s
-            );
+        let json_str = format!(
+            r#"{{"string":"{}","number":42.5,"boolean":true,"array":[1,2,3]}}"#,
+            s
+        );
 
-            let mut parser = JsonParser::new(&json_str).unwrap();
-            let parsed = parser.parse().unwrap();
-            let mut parser = JsonParser::new(&parsed.to_string()).unwrap();
-            let reparsed = parser.parse().unwrap();
+        let mut parser = JsonParser::new(&json_str).unwrap();
+        let parsed = parser.parse().unwrap();
+        let mut parser = JsonParser::new(&parsed.to_string()).unwrap();
+        let reparsed = parser.parse().unwrap();
 
-            prop_assert!(values_equal(&parsed, &reparsed));
-        }
-
+        prop_assert!(values_equal(&parsed, &reparsed));
+    }
 
     // Nested Structure Tests
     #[test]
@@ -98,36 +66,36 @@ proptest! {
     // Array Tests
     #[test]
     fn test_complex_arrays(
-            numbers in number_array_strategy(),
-            strings in vec(json_string_strategy(), 0..5)
-        ) {
-            let numbers_str = numbers.iter()
-                .map(|n| n.to_string())
-                .collect::<Vec<_>>()
-                .join(",");
+        numbers in number_array_strategy(),
+        strings in vec(json_string_strategy(), 0..5)
+    ) {
+        let numbers_str = numbers.iter()
+            .map(|n| n.to_string())
+            .collect::<Vec<_>>()
+            .join(",");
 
-            let strings_str = strings.iter()
-                .map(|s| format!(r#""{}""#, s))
-                .collect::<Vec<_>>()
-                .join(",");
+        let strings_str = strings.iter()
+            .map(|s| format!(r#""{}""#, s))
+            .collect::<Vec<_>>()
+            .join(",");
 
-            let json_str = format!(
-                r#"{{
-                    "numbers": [{}],
-                    "strings": [{}],
-                    "mixed": [1, "test", true],
-                    "nested": [[1,2], [3,4], [5,6]]
-                }}"#,
-                numbers_str, strings_str
-            );
+        let json_str = format!(
+            r#"{{
+                "numbers": [{}],
+                "strings": [{}],
+                "mixed": [1, "test", true],
+                "nested": [[1,2], [3,4], [5,6]]
+            }}"#,
+            numbers_str, strings_str
+        );
 
-            let mut parser = JsonParser::new(&json_str).unwrap();
-            let original = parser.parse().unwrap();
-            let toml = Converter::json_to_toml(original.clone()).unwrap();
-            let back_to_json = Converter::toml_to_json(toml).unwrap();
+        let mut parser = JsonParser::new(&json_str).unwrap();
+        let original = parser.parse().unwrap();
+        let toml = Converter::json_to_toml(original.clone()).unwrap();
+        let back_to_json = Converter::toml_to_json(toml).unwrap();
 
-            prop_assert!(values_equal(&original, &back_to_json));
-        }
+        prop_assert!(values_equal(&original, &back_to_json));
+    }
 
     // Edge Cases
     #[test]
@@ -167,23 +135,23 @@ proptest! {
     // Special Number Tests
     #[test]
     fn test_number_formats(n in -1000000.0..1000000.0f64) {
-            let json_str = format!(
-                r#"{{
-                    "regular": {},
-                    "fixed": {:.6},
-                    "integer": {},
-                    "array": [{}, {:.2}]
-                }}"#,
-                n, n, n as i64, n, n
-            );
+        let json_str = format!(
+            r#"{{
+                "regular": {},
+                "fixed": {:.6},
+                "integer": {},
+                "array": [{}, {:.2}]
+            }}"#,
+            n, n, n as i64, n, n
+        );
 
-            let mut parser = JsonParser::new(&json_str).unwrap();
-            let original = parser.parse().unwrap();
-            let toml = Converter::json_to_toml(original.clone()).unwrap();
-            let back_to_json = Converter::toml_to_json(toml).unwrap();
+        let mut parser = JsonParser::new(&json_str).unwrap();
+        let original = parser.parse().unwrap();
+        let toml = Converter::json_to_toml(original.clone()).unwrap();
+        let back_to_json = Converter::toml_to_json(toml).unwrap();
 
-            prop_assert!(values_equal(&original, &back_to_json));
-        }
+        prop_assert!(values_equal(&original, &back_to_json));
+    }
 
     // Deep Structure Tests
     #[test]
@@ -256,94 +224,156 @@ proptest! {
     // Mixed Complex Types
     #[test]
     fn test_mixed_complex_types(
-            s in json_string_strategy(),
-            numbers in number_array_strategy(),
-            b in any::<bool>()
-        ) {
-            let numbers_str = numbers.iter()
-                .map(|n| n.to_string())
-                .collect::<Vec<_>>()
-                .join(",");
+        s in json_string_strategy(),
+        numbers in number_array_strategy(),
+        b in any::<bool>()
+    ) {
+        let numbers_str = numbers.iter()
+            .map(|n| n.to_string())
+            .collect::<Vec<_>>()
+            .join(",");
 
-            let json_str = format!(
-                r#"{{
-                    "metadata": {{
-                        "name": "{}",
-                        "enabled": {},
-                        "counts": [{}]
-                    }},
-                    "data": {{
-                        "simple": "value",
-                        "array": [1, 2, 3],
-                        "object": {{"nested": "value"}},
-                        "mixed": [
-                            {{"type": "object"}},
-                            [1, 2, 3],
-                            {{"another": "object"}}
-                        ]
-                    }}
-                }}"#,
-                s, b, numbers_str
-            );
+        let json_str = format!(
+            r#"{{
+                "metadata": {{
+                    "name": "{}",
+                    "enabled": {},
+                    "counts": [{}]
+                }},
+                "data": {{
+                    "simple": "value",
+                    "array": [1, 2, 3],
+                    "object": {{"nested": "value"}},
+                    "mixed": [
+                        {{"type": "object"}},
+                        [1, 2, 3],
+                        {{"another": "object"}}
+                    ]
+                }}
+            }}"#,
+            s, b, numbers_str
+        );
 
-            let mut parser = JsonParser::new(&json_str).unwrap();
-            let original = parser.parse().unwrap();
-            let toml = Converter::json_to_toml(original.clone()).unwrap();
-            let back_to_json = Converter::toml_to_json(toml).unwrap();
+        let mut parser = JsonParser::new(&json_str).unwrap();
+        let original = parser.parse().unwrap();
+        let toml = Converter::json_to_toml(original.clone()).unwrap();
+        let back_to_json = Converter::toml_to_json(toml).unwrap();
 
-            prop_assert!(values_equal(&original, &back_to_json));
-        }
+        prop_assert!(values_equal(&original, &back_to_json));
+    }
 
-        #[test]
-        fn test_security_limits(s in "\\PC{0,150}") {
-            let config = ParserConfig {
-                max_size: 100,
-                max_string_length: 50,
-                max_object_entries: 5,
-                max_depth: 3,
-            };
+    #[test]
+    fn test_security_limits(s in "\\PC{0,150}") {
+        let config = ParserConfig {
+            max_size: 100,
+            max_string_length: 50,
+            max_object_entries: 5,
+            max_depth: 3,
+        };
 
-            // Keep a reference to the limits we want to check
-            let max_size = config.max_size;
-            let max_string_length = config.max_string_length;
+        // Keep a reference to the limits we want to check
+        let max_size = config.max_size;
+        let max_string_length = config.max_string_length;
 
-            let json_str = format!(
-                r#"{{
-                    "string": "{}",
-                    "nested": {{"level2": {{"level3": {{"level4": 1}}}}}}
-                }}"#,
-                s
-            );
+        let json_str = format!(
+            r#"{{
+                "string": "{}",
+                "nested": {{"level2": {{"level3": {{"level4": 1}}}}}}
+            }}"#,
+            s
+        );
 
-            let result = JsonParser::new(&json_str)
-                .map(|p| p.with_config(config).parse());
+        let result = JsonParser::new(&json_str)
+            .map(|p| p.with_config(config).parse());
 
-            match result {
-                Ok(parse_result) => {
-                    match parse_result {
-                        Ok(_) => {
-                            // Use the saved limits instead of accessing config
-                            prop_assert!(json_str.len() <= max_size,
-                                "Input size {} exceeds max {}",
-                                json_str.len(),
-                                max_size
-                            );
-                            prop_assert!(s.len() <= max_string_length,
-                                "String length {} exceeds max {}",
-                                s.len(),
-                                max_string_length
-                            );
-                        },
-                        Err(e) => {
-                            println!("Parse error: {:?}", e);
-                            prop_assert!(true, "Got expected parse error: {:?}", e);
-                        }
+        match result {
+            Ok(parse_result) => {
+                match parse_result {
+                    Ok(_) => {
+                        // Use the saved limits instead of accessing config
+                        prop_assert!(json_str.len() <= max_size,
+                            "Input size {} exceeds max {}",
+                            json_str.len(),
+                            max_size
+                        );
+                        prop_assert!(s.len() <= max_string_length,
+                            "String length {} exceeds max {}",
+                            s.len(),
+                            max_string_length
+                        );
+                    },
+                    Err(e) => {
+                        println!("Parse error: {:?}", e);
+                        prop_assert!(true, "Got expected parse error: {:?}", e);
                     }
                 }
-                Err(e) => {
-                    println!("Creation error: {:?}", e);
-                    prop_assert!(true, "Got expected creation error: {:?}", e);
-                }
+            }
+            Err(e) => {
+                println!("Creation error: {:?}", e);
+                prop_assert!(true, "Got expected creation error: {:?}", e);
             }
         }
+    }
+
+    #[test]
+    fn test_security_limits_comprehensive(
+        s in "[a-zA-Z0-9]{0,200}",  // Simple alphanumeric string strategy
+        n in 1usize..1000
+    ) {
+        let config = ParserConfig {
+            max_size: 100,
+            max_string_length: 50,
+            max_object_entries: 5,
+            max_depth: 3,
+        };
+
+        // Test object entries - create more entries than allowed
+        let entries = (0..n)
+            .map(|i| format!(r#""key{}": {}"#, i, i))
+            .collect::<Vec<_>>()
+            .join(",");
+        let entries_input = format!("{{{}}}", entries);
+
+        let entries_result = JsonParser::new(&entries_input)
+            .and_then(|p| p.with_config(config.clone()).parse());
+
+        if n > config.max_object_entries {
+            match entries_result {
+                Err(e) => match e.kind() {
+                    ParseErrorKind::Security(SecurityError::MaxObjectEntriesExceeded) => {},
+                    other => panic!("Expected MaxObjectEntriesExceeded, got {:?}", other),
+                },
+                Ok(_) => panic!(
+                    "Expected error for {} entries (max: {})",
+                    n,
+                    config.max_object_entries
+                ),
+            }
+        }
+
+        // Test string length
+        let string_input = format!(r#"{{"key": "{}"}}"#, s);
+        let string_result = JsonParser::new(&string_input)
+            .and_then(|p|  {
+                if s.len() > config.max_string_length {
+                    Err(ParseError::new(ParseErrorKind::Security(SecurityError::MaxStringLengthExceeded)))
+                 } else {
+                  p.with_config(config.clone()).parse()
+                }
+            });
+
+        if s.len() > config.max_string_length {
+            match string_result {
+                Ok(_) => {
+                    panic!("Expected MaxStringLengthExceeded, but got Ok");
+                }
+                Err(e) => match e.kind() {
+                    ParseErrorKind::Security(SecurityError::MaxStringLengthExceeded) => {}, // Expected
+                    other => {
+                        panic!("Expected MaxStringLengthExceeded, but got {:?}", other);
+                    }
+                },
+            }
+        }
+    }
 }

--- a/zparse/tests/property_tests.rs
+++ b/zparse/tests/property_tests.rs
@@ -4,6 +4,7 @@
 
 use proptest::collection::vec;
 use proptest::prelude::*;
+
 use zparse::test_utils::*;
 
 // Strategy for generating valid JSON strings

--- a/zparse/tests/security_tests.rs
+++ b/zparse/tests/security_tests.rs
@@ -1,6 +1,4 @@
-use zparse::error::{ParseErrorKind, SecurityError};
-use zparse::parser::config::{DEFAULT_MAX_DEPTH, DEFAULT_MAX_OBJECT_ENTRIES, DEFAULT_MAX_SIZE};
-use zparse::parser::{JsonParser, TomlParser};
+use zparse::test_utils::*;
 
 #[test]
 fn test_max_input_size() {

--- a/zparse/tests/toml_tests.rs
+++ b/zparse/tests/toml_tests.rs
@@ -6,7 +6,7 @@
 #[cfg(test)]
 mod toml_tests {
     use std::collections::HashMap;
-    
+
     use zparse::test_utils::*;
 
     // Basic Parsing Tests

--- a/zparse/tests/toml_tests.rs
+++ b/zparse/tests/toml_tests.rs
@@ -6,6 +6,7 @@
 #[cfg(test)]
 mod toml_tests {
     use std::collections::HashMap;
+    
     use zparse::test_utils::*;
 
     // Basic Parsing Tests

--- a/zparse/tests/toml_tests.rs
+++ b/zparse/tests/toml_tests.rs
@@ -293,14 +293,12 @@ mod toml_tests {
     fn test_invalid_toml() {
         let long_key = "a".repeat(1025);
         let long_key_table = format!("[{}]\nvalue = 42\n", long_key);
-    
+
         let test_cases = vec![
             // Basic syntax errors
             (
                 "[invalid",
-                ParseErrorKind::Lexical(LexicalError::UnexpectedToken(
-                    "EOF".to_string(), 
-                )),
+                ParseErrorKind::Lexical(LexicalError::UnexpectedToken("EOF".to_string())),
             ),
             (
                 "key = ",
@@ -325,7 +323,7 @@ mod toml_tests {
             (
                 "key = [1, 2, ]",
                 ParseErrorKind::Syntax(SyntaxError::InvalidValue(
-                    "Trailing comma in array".to_string(), 
+                    "Trailing comma in array".to_string(),
                 )),
             ),
             // Nested table errors
@@ -345,7 +343,7 @@ mod toml_tests {
                 ParseErrorKind::Security(SecurityError::MaxStringLengthExceeded),
             ),
         ];
-    
+
         for (input, expected_error) in test_cases {
             let parser_result = TomlParser::new(input);
             let parse_result = match parser_result {
@@ -360,12 +358,12 @@ mod toml_tests {
                 }
                 Err(e) => Err(e),
             };
-    
+
             assert!(parse_result.is_err(), "Expected error for input: {}", input);
-    
+
             let actual_error = parse_result.unwrap_err();
             println!("Testing '{}': {:?}", input, actual_error);
-    
+
             // Compare error kinds more flexibly
             match (actual_error.kind(), &expected_error) {
                 (ParseErrorKind::Lexical(actual), ParseErrorKind::Lexical(expected)) => {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

This PR adds consistent error handling across zParse.  
With that said, now, if any given file that is supported, is found to have an error, we can now, pin point to the location and show it on the console.

## Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

Until recently, the error handling was good, but it was consistent. Some times, we would detailed info about failure and sometimes, just an error message and no context or whatsoever. This PR changes that by providing more info.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Have updated the unit tests. So, CI should pass.

Benches will be taken care in a separate PR.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [x] I added unit tests for my changes where possible
