### PR TITLE
refactor: use reference instead of cloning

### DIFF
--- a/fuzz/fuzz_targets/json_converter.rs
+++ b/fuzz/fuzz_targets/json_converter.rs
@@ -6,7 +6,7 @@ fuzz_target!(|data: &[u8]| {
     if let Ok(s) = std::str::from_utf8(data) {
         if let Ok(mut parser) = JsonParser::new(s) {
             if let Ok(value) = parser.parse() {
-                let _ = Converter::json_to_toml(value);
+                let _ = Converter::json_to_toml(&value);
             }
         }
     }

--- a/fuzz/fuzz_targets/toml_converter.rs
+++ b/fuzz/fuzz_targets/toml_converter.rs
@@ -6,7 +6,7 @@ fuzz_target!(|data: &[u8]| {
     if let Ok(s) = std::str::from_utf8(data) {
         if let Ok(mut parser) = TomlParser::new(s) {
             if let Ok(value) = parser.parse() {
-                let _ = Converter::toml_to_json(value);
+                let _ = Converter::toml_to_json(&value);
             }
         }
     }

--- a/zparse/benches/parser_benchmarks.rs
+++ b/zparse/benches/parser_benchmarks.rs
@@ -64,11 +64,11 @@ fn bench_conversions(c: &mut Criterion) {
     let toml_value = toml_parser.parse().unwrap();
 
     group.bench_function("json_to_toml", |b| {
-        b.iter(|| Converter::json_to_toml(black_box(json_value.clone())).unwrap());
+        b.iter(|| Converter::json_to_toml(black_box(&json_value)).unwrap());
     });
 
     group.bench_function("toml_to_json", |b| {
-        b.iter(|| Converter::toml_to_json(black_box(toml_value.clone())).unwrap());
+        b.iter(|| Converter::toml_to_json(black_box(&toml_value)).unwrap());
     });
 
     group.finish();

--- a/zparse/src/converter/json_to_toml.rs
+++ b/zparse/src/converter/json_to_toml.rs
@@ -38,10 +38,10 @@ impl CommonConverter for JsonToTomlConverter {
         Ok(Value::Array(converted))
     }
 
-    fn convert_value(value: Value, ctx: &mut ConversionContext) -> Result<Value> {
+    fn convert_value(value: &Value, ctx: &mut ConversionContext) -> Result<Value> {
         match value {
-            Value::Map(map) => Self::convert_map(map, ctx),
-            Value::Array(arr) => Self::convert_array(arr, ctx),
+            Value::Map(map) => Self::convert_map(map.clone(), ctx),
+            Value::Array(arr) => Self::convert_array(arr.clone(), ctx),
             Value::Null => {
                 let location = ctx.create_location();
                 let path = ctx.get_path();
@@ -72,7 +72,7 @@ impl JsonToTomlConverter {
     /// # Returns
     /// * `Ok(Value)` - The converted TOML value
     /// * `Err` - If the JSON structure cannot be represented in TOML
-    pub fn convert(value: Value) -> Result<Value> {
+    pub fn convert(value: &Value) -> Result<Value> {
         let map = Self::validate_root(value)?;
         let mut ctx = ConversionContext::new();
         Self::convert_map(map, &mut ctx)

--- a/zparse/src/converter/toml_to_json.rs
+++ b/zparse/src/converter/toml_to_json.rs
@@ -16,17 +16,17 @@ impl CommonConverter for TomlToJsonConverter {
         Ok(Value::Array(converted))
     }
 
-    fn convert_value(value: Value, ctx: &mut ConversionContext) -> Result<Value> {
+    fn convert_value(value: &Value, ctx: &mut ConversionContext) -> Result<Value> {
         match value {
-            Value::Map(map) => Self::convert_map(map, ctx),
-            Value::Array(arr) => Self::convert_array(arr, ctx),
+            Value::Map(map) => Self::convert_map(map.clone(), ctx),
+            Value::Array(arr) => Self::convert_array(arr.clone(), ctx),
             _ => Ok(value),
         }
     }
 }
 
 impl TomlToJsonConverter {
-    pub fn convert(value: Value) -> Result<Value> {
+    pub fn convert(value: &Value) -> Result<Value> {
         let map = Self::validate_root(value)?;
         let mut ctx = ConversionContext::new();
         Self::convert_map(map, &mut ctx)

--- a/zparse/src/formatter/json.rs
+++ b/zparse/src/formatter/json.rs
@@ -9,7 +9,7 @@ impl CommonFormatter for JsonFormatter {}
 
 impl Formatter for JsonFormatter {
     fn format(&self, value: &Value, config: &FormatConfig) -> Result<String> {
-        Ok(Self::format_value(value, 0, config))?
+        Self::format_value(value, 0, config)
     }
 }
 

--- a/zparse/src/main.rs
+++ b/zparse/src/main.rs
@@ -73,8 +73,8 @@ fn run() -> Result<()> {
     // Handle conversion if requested
     let (final_value, output_format) = if let Some(convert_to) = args.convert {
         match (input_ext, convert_to.as_str()) {
-            ("json", "toml") => (Converter::json_to_toml(parsed_value)?, "toml"),
-            ("toml", "json") => (Converter::toml_to_json(parsed_value)?, "json"),
+            ("json", "toml") => (Converter::json_to_toml(&parsed_value)?, "toml"),
+            ("toml", "json") => (Converter::toml_to_json(&parsed_value)?, "json"),
             _ => {
                 return Err(ParseError::new(ParseErrorKind::Syntax(
                     SyntaxError::InvalidValue("conversion".to_string()),

--- a/zparse/tests/conversion_tests.rs
+++ b/zparse/tests/conversion_tests.rs
@@ -11,7 +11,7 @@ fn test_json_to_toml_conversion() -> Result<()> {
 
     let mut json_parser = JsonParser::new(&test_data.medium_json)?;
     let json_value = json_parser.parse()?;
-    let toml_value = Converter::json_to_toml(json_value.clone())?;
+    let toml_value = Converter::json_to_toml(&json_value)?;
 
     let mut toml_parser = TomlParser::new(&test_data.medium_toml)?;
     let expected_value = toml_parser.parse()?;
@@ -30,7 +30,7 @@ fn test_toml_to_json_conversion() -> Result<()> {
 
     let mut toml_parser = TomlParser::new(&test_data.medium_toml)?;
     let toml_value = toml_parser.parse()?;
-    let json_value = Converter::toml_to_json(toml_value.clone())?;
+    let json_value = Converter::toml_to_json(&toml_value)?;
 
     let mut json_parser = JsonParser::new(&test_data.medium_json)?;
     let expected_value = json_parser.parse()?;
@@ -99,8 +99,8 @@ fn test_json_toml_json_roundtrip() -> Result<()> {
     let mut original_json = JsonParser::new(&test_data.medium_json)?;
     let json_value = original_json.parse()?;
 
-    let toml_value = Converter::json_to_toml(json_value.clone())?;
-    let converted_back = Converter::toml_to_json(toml_value.clone())?;
+    let toml_value = Converter::json_to_toml(&json_value)?;
+    let converted_back = Converter::toml_to_json(&toml_value)?;
 
     assert_values_equal(
         &toml_value,
@@ -118,8 +118,8 @@ fn test_toml_json_toml_roundtrip() -> Result<()> {
     let mut original_toml = TomlParser::new(&test_data.medium_toml)?;
     let toml_value = original_toml.parse()?;
 
-    let json_value = Converter::toml_to_json(toml_value.clone())?;
-    let converted_back = Converter::json_to_toml(json_value.clone())?;
+    let json_value = Converter::toml_to_json(&toml_value)?;
+    let converted_back = Converter::json_to_toml(&json_value)?;
 
     assert_values_equal(
         &json_value,
@@ -136,7 +136,7 @@ fn converter_null_value_error() {
     // because TOML does not support null values.
     let input = r#"{"key": null}"#;
     let json_value = parse_json(input).expect("JSON should parse successfully");
-    let result = Converter::json_to_toml(json_value);
+    let result = Converter::json_to_toml(&json_value);
     assert!(result.is_err(), "Expected converter error for null value");
 
     let err = result.unwrap_err();
@@ -157,7 +157,7 @@ fn converter_null_value_error() {
 fn test_array_with_null_conversion() {
     let input = r#"{"array": [1, null, 3]}"#;
     let json_value = parse_json(input).expect("JSON should parse successfully");
-    let result = Converter::json_to_toml(json_value);
+    let result = Converter::json_to_toml(&json_value);
     assert!(result.is_err(), "Expected error for array containing null");
 
     let err = result.unwrap_err();
@@ -180,7 +180,7 @@ fn test_array_with_null_conversion() {
 fn test_error_location_tracking() -> Result<()> {
     let input = r#"{"key": null}"#; // Invalid TOML value
     let json_value = parse_json(input)?;
-    let result = Converter::json_to_toml(json_value);
+    let result = Converter::json_to_toml(&json_value);
 
     assert!(result.is_err());
     let err = result.unwrap_err();
@@ -213,7 +213,7 @@ fn test_nested_location_tracking() -> Result<()> {
         }
     }"#;
     let json_value = parse_json(input)?;
-    let result = Converter::json_to_toml(json_value);
+    let result = Converter::json_to_toml(&json_value);
 
     assert!(result.is_err());
     let err = result.unwrap_err();

--- a/zparse/tests/json_tests.rs
+++ b/zparse/tests/json_tests.rs
@@ -195,7 +195,7 @@ mod json_tests {
 
         let mut parser = JsonParser::new(input)?;
         let json_value = parser.parse()?;
-        let toml_value = Converter::json_to_toml(json_value)?;
+        let toml_value = Converter::json_to_toml(&json_value)?;
 
         // Verify the conversion maintained the structure
         if let Value::Map(root) = toml_value {

--- a/zparse/tests/property_tests.rs
+++ b/zparse/tests/property_tests.rs
@@ -57,8 +57,8 @@ proptest! {
 
         let mut parser = JsonParser::new(&json_str).unwrap();
         let original = parser.parse().unwrap();
-        let toml = Converter::json_to_toml(original.clone()).unwrap();
-        let back_to_json = Converter::toml_to_json(toml).unwrap();
+        let toml = Converter::json_to_toml(&original).unwrap();
+        let back_to_json = Converter::toml_to_json(&toml).unwrap();
 
         prop_assert!(values_equal(&original, &back_to_json));
     }
@@ -91,8 +91,8 @@ proptest! {
 
         let mut parser = JsonParser::new(&json_str).unwrap();
         let original = parser.parse().unwrap();
-        let toml = Converter::json_to_toml(original.clone()).unwrap();
-        let back_to_json = Converter::toml_to_json(toml).unwrap();
+        let toml = Converter::json_to_toml(&original).unwrap();
+        let back_to_json = Converter::toml_to_json(&toml).unwrap();
 
         prop_assert!(values_equal(&original, &back_to_json));
     }
@@ -125,8 +125,8 @@ proptest! {
         for case in edge_cases {
             let mut parser = JsonParser::new(&case).unwrap();
             let original = parser.parse().unwrap();
-            let toml = Converter::json_to_toml(original.clone()).unwrap();
-            let back_to_json = Converter::toml_to_json(toml).unwrap();
+            let toml = Converter::json_to_toml(&original).unwrap();
+            let back_to_json = Converter::toml_to_json(&toml).unwrap();
 
             prop_assert!(values_equal(&original, &back_to_json));
         }
@@ -147,8 +147,8 @@ proptest! {
 
         let mut parser = JsonParser::new(&json_str).unwrap();
         let original = parser.parse().unwrap();
-        let toml = Converter::json_to_toml(original.clone()).unwrap();
-        let back_to_json = Converter::toml_to_json(toml).unwrap();
+        let toml = Converter::json_to_toml(&original).unwrap();
+        let back_to_json = Converter::toml_to_json(&toml).unwrap();
 
         prop_assert!(values_equal(&original, &back_to_json));
     }
@@ -186,8 +186,8 @@ proptest! {
 
         let mut parser = JsonParser::new(&json_str).unwrap();
         let original = parser.parse().unwrap();
-        let toml = Converter::json_to_toml(original.clone()).unwrap();
-        let back_to_json = Converter::toml_to_json(toml).unwrap();
+        let toml = Converter::json_to_toml(&original).unwrap();
+        let back_to_json = Converter::toml_to_json(&toml).unwrap();
 
         prop_assert!(values_equal(&original, &back_to_json));
     }
@@ -215,8 +215,8 @@ proptest! {
 
         let mut parser = JsonParser::new(&json_str).unwrap();
         let original = parser.parse().unwrap();
-        let toml = Converter::json_to_toml(original.clone()).unwrap();
-        let back_to_json = Converter::toml_to_json(toml).unwrap();
+        let toml = Converter::json_to_toml(&original).unwrap();
+        let back_to_json = Converter::toml_to_json(&toml).unwrap();
 
         prop_assert!(values_equal(&original, &back_to_json));
     }
@@ -256,8 +256,8 @@ proptest! {
 
         let mut parser = JsonParser::new(&json_str).unwrap();
         let original = parser.parse().unwrap();
-        let toml = Converter::json_to_toml(original.clone()).unwrap();
-        let back_to_json = Converter::toml_to_json(toml).unwrap();
+        let toml = Converter::json_to_toml(&original).unwrap();
+        let back_to_json = Converter::toml_to_json(&toml).unwrap();
 
         prop_assert!(values_equal(&original, &back_to_json));
     }

--- a/zparse/tests/toml_tests.rs
+++ b/zparse/tests/toml_tests.rs
@@ -276,7 +276,7 @@ mod toml_tests {
 
         let mut parser = TomlParser::new(input)?;
         let toml_value = parser.parse()?;
-        let json_value = Converter::toml_to_json(toml_value)?;
+        let json_value = Converter::toml_to_json(&toml_value)?;
 
         // Verify the conversion maintained the structure
         if let Value::Map(root) = json_value {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

Small refactor to use reference instead of just cloning stuff.

## Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

i feel, using reference makes more sense.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

ci should pass.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
