### PR TITLE
refactor(core): standardise apis

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,14 @@
 [workspace]
-members = [
-    "zparse",
-    "fuzz"
-]
+members = ["zparse", "fuzz"]
 resolver = "2"
 
 [workspace.package]
 version = "1.0.0"
 edition = "2021"
 authors = ["Pa1Nark <pa1nark@pixincreate.dev>"]
-license = "GPL-3.0"
+license-file = "LICENSE"
+readme = "README.md"
+repository = "https://github.com/pixincreate/zParse"
+keywords = ["zparse", "parser", "json", "toml"]
+categories = ["command-line-utilities", "development-tools"]
+

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -3,7 +3,7 @@ name = "zparse-fuzz"
 version.workspace = true
 edition.workspace = true
 publish = false
-license.workspace = true
+license-file.workspace = true
 
 [package.metadata]
 cargo-fuzz = true

--- a/fuzz/fuzz_targets/json_converter.rs
+++ b/fuzz/fuzz_targets/json_converter.rs
@@ -6,7 +6,7 @@ fuzz_target!(|data: &[u8]| {
     if let Ok(s) = std::str::from_utf8(data) {
         if let Ok(mut parser) = JsonParser::new(s) {
             if let Ok(value) = parser.parse() {
-                let _ = Converter::json_to_toml(value);
+                let _ = Converter::json_to_toml(&value);
             }
         }
     }

--- a/fuzz/fuzz_targets/toml_converter.rs
+++ b/fuzz/fuzz_targets/toml_converter.rs
@@ -6,7 +6,7 @@ fuzz_target!(|data: &[u8]| {
     if let Ok(s) = std::str::from_utf8(data) {
         if let Ok(mut parser) = TomlParser::new(s) {
             if let Ok(value) = parser.parse() {
-                let _ = Converter::toml_to_json(value);
+                let _ = Converter::toml_to_json(&value);
             }
         }
     }

--- a/zparse/Cargo.toml
+++ b/zparse/Cargo.toml
@@ -5,7 +5,9 @@ authors.workspace = true
 edition.workspace = true
 rust-version = "1.82.0"
 description = "A robust parser and converter library for JSON and TOML files written in Rust."
-license.workspace = true
+license-file.workspace = true
+readme.workspace = true
+repository.workspace = true
 
 [dependencies]
 clap = { version = "4.5.31", features = ["std", "derive", "help", "usage"] }

--- a/zparse/benches/parser_benchmarks.rs
+++ b/zparse/benches/parser_benchmarks.rs
@@ -64,11 +64,11 @@ fn bench_conversions(c: &mut Criterion) {
     let toml_value = toml_parser.parse().unwrap();
 
     group.bench_function("json_to_toml", |b| {
-        b.iter(|| Converter::json_to_toml(black_box(json_value.clone())).unwrap());
+        b.iter(|| Converter::json_to_toml(black_box(&json_value)).unwrap());
     });
 
     group.bench_function("toml_to_json", |b| {
-        b.iter(|| Converter::toml_to_json(black_box(toml_value.clone())).unwrap());
+        b.iter(|| Converter::toml_to_json(black_box(&toml_value)).unwrap());
     });
 
     group.finish();

--- a/zparse/src/converter/json_to_toml.rs
+++ b/zparse/src/converter/json_to_toml.rs
@@ -58,7 +58,10 @@ impl CommonConverter for JsonToTomlConverter {
                     &context,
                 ))
             }
-            _ => Ok(value),
+            Value::Boolean(b) => Ok(Value::Boolean(*b)),
+            Value::Number(n) => Ok(Value::Number(*n)),
+            Value::String(s) => Ok(Value::String(s.clone())),
+            Value::DateTime(dt) => Ok(Value::DateTime(dt.clone())),
         }
     }
 }

--- a/zparse/src/converter/json_to_toml.rs
+++ b/zparse/src/converter/json_to_toml.rs
@@ -38,10 +38,10 @@ impl CommonConverter for JsonToTomlConverter {
         Ok(Value::Array(converted))
     }
 
-    fn convert_value(value: Value, ctx: &mut ConversionContext) -> Result<Value> {
+    fn convert_value(value: &Value, ctx: &mut ConversionContext) -> Result<Value> {
         match value {
-            Value::Map(map) => Self::convert_map(map, ctx),
-            Value::Array(arr) => Self::convert_array(arr, ctx),
+            Value::Map(map) => Self::convert_map(map.clone(), ctx),
+            Value::Array(arr) => Self::convert_array(arr.clone(), ctx),
             Value::Null => {
                 let location = ctx.create_location();
                 let path = ctx.get_path();
@@ -72,7 +72,7 @@ impl JsonToTomlConverter {
     /// # Returns
     /// * `Ok(Value)` - The converted TOML value
     /// * `Err` - If the JSON structure cannot be represented in TOML
-    pub fn convert(value: Value) -> Result<Value> {
+    pub fn convert(value: &Value) -> Result<Value> {
         let map = Self::validate_root(value)?;
         let mut ctx = ConversionContext::new();
         Self::convert_map(map, &mut ctx)

--- a/zparse/src/converter/toml_to_json.rs
+++ b/zparse/src/converter/toml_to_json.rs
@@ -16,17 +16,17 @@ impl CommonConverter for TomlToJsonConverter {
         Ok(Value::Array(converted))
     }
 
-    fn convert_value(value: Value, ctx: &mut ConversionContext) -> Result<Value> {
+    fn convert_value(value: &Value, ctx: &mut ConversionContext) -> Result<Value> {
         match value {
-            Value::Map(map) => Self::convert_map(map, ctx),
-            Value::Array(arr) => Self::convert_array(arr, ctx),
+            Value::Map(map) => Self::convert_map(map.clone(), ctx),
+            Value::Array(arr) => Self::convert_array(arr.clone(), ctx),
             _ => Ok(value),
         }
     }
 }
 
 impl TomlToJsonConverter {
-    pub fn convert(value: Value) -> Result<Value> {
+    pub fn convert(value: &Value) -> Result<Value> {
         let map = Self::validate_root(value)?;
         let mut ctx = ConversionContext::new();
         Self::convert_map(map, &mut ctx)

--- a/zparse/src/converter/toml_to_json.rs
+++ b/zparse/src/converter/toml_to_json.rs
@@ -20,7 +20,11 @@ impl CommonConverter for TomlToJsonConverter {
         match value {
             Value::Map(map) => Self::convert_map(map.clone(), ctx),
             Value::Array(arr) => Self::convert_array(arr.clone(), ctx),
-            _ => Ok(value),
+            Value::Boolean(b) => Ok(Value::Boolean(*b)),
+            Value::Number(n) => Ok(Value::Number(*n)),
+            Value::String(s) => Ok(Value::String(s.clone())),
+            Value::DateTime(dt) => Ok(Value::DateTime(dt.clone())),
+            Value::Null => Ok(Value::Null),
         }
     }
 }

--- a/zparse/src/enums.rs
+++ b/zparse/src/enums.rs
@@ -32,3 +32,24 @@ impl fmt::Display for FileType {
         }
     }
 }
+
+impl fmt::Display for Token {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::LeftBrace => write!(f, "{{"),
+            Self::RightBrace => write!(f, "}}"),
+            Self::LeftBracket => write!(f, "["),
+            Self::RightBracket => write!(f, "]"),
+            Self::Colon => write!(f, ":"),
+            Self::Comma => write!(f, ","),
+            Self::Equals => write!(f, "="),
+            Self::Dot => write!(f, "."),
+            Self::String(s) => write!(f, "\"{}\"", s),
+            Self::Number(n) => write!(f, "{}", n),
+            Self::Boolean(b) => write!(f, "{}", b),
+            Self::DateTime(dt) => write!(f, "{}", dt),
+            Self::Null => write!(f, "null"),
+            Self::EOF => write!(f, "EOF"),
+        }
+    }
+}

--- a/zparse/src/formatter.rs
+++ b/zparse/src/formatter.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 mod json;
 mod toml;
 
@@ -23,6 +25,16 @@ impl Default for FormatConfig {
             indent_spaces: 2,
             sort_keys: true,
         }
+    }
+}
+
+impl fmt::Display for FormatConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "FormatConfig {{ indent_spaces: {}, sort_keys: {} }}",
+            self.indent_spaces, self.sort_keys
+        )
     }
 }
 

--- a/zparse/src/formatter/json.rs
+++ b/zparse/src/formatter/json.rs
@@ -9,7 +9,7 @@ impl CommonFormatter for JsonFormatter {}
 
 impl Formatter for JsonFormatter {
     fn format(&self, value: &Value, config: &FormatConfig) -> Result<String> {
-        Ok(Self::format_value(value, 0, config))?
+        Self::format_value(value, 0, config)
     }
 }
 

--- a/zparse/src/lib.rs
+++ b/zparse/src/lib.rs
@@ -7,12 +7,45 @@
 //! - Handle errors with detailed context
 //!
 //! # Examples
-//! ```
+//!
+//! ## Parsing a file
+//! ```no_run
 //! use zparse::{parse_file, error::Result};
 //!
 //! fn example() -> Result<()> {
 //!     let value = parse_file("config.json")?;
 //!     println!("Parsed value: {}", value);
+//!     Ok(())
+//! }
+//! ```
+//!
+//! ## Parsing from string
+//! ```
+//! use zparse::{parse_json, error::Result, ValueExt};
+//!
+//! fn example() -> Result<()> {
+//!     let json_str = r#"{"name": "test", "value": 42}"#;
+//!     let value = parse_json(json_str)?;
+//!     println!("Parsed name: {}", value.get_string("name").unwrap_or_default());
+//!     println!("Parsed value: {}", value.get_number("value").unwrap_or_default());
+//!     Ok(())
+//! }
+//! ```
+//!
+//! ## Converting between formats
+//! ```no_run
+//! use zparse::{parse_json, converter::Converter, error::Result};
+//!
+//! fn example() -> Result<()> {
+//!     let json_str = r#"{"name": "test", "value": 42}"#;
+//!     let json_value = parse_json(json_str)?;
+//!
+//!     // Convert JSON to TOML
+//!     let toml_value = Converter::json_to_toml(&json_value)?;
+//!
+//!     // Format as TOML string
+//!     let toml_str = zparse::format_toml(&toml_value)?;
+//!     println!("TOML output:\n{}", toml_str);
 //!     Ok(())
 //! }
 //! ```
@@ -24,14 +57,38 @@ pub mod enums;
 pub mod error;
 pub mod formatter;
 pub mod parser;
+#[doc(hidden)]
 pub mod test_utils;
 pub mod utils;
 
-// Re-exports
-use error::{IOError, ParseError, ParseErrorKind, Result, SemanticError};
-use parser::value::Value;
-use utils::{parse_json, parse_toml};
+// Re-exports for convenient access
+pub use error::{IOError, ParseError, ParseErrorKind, Result, SemanticError};
+pub use parser::value::Value;
+pub use utils::{format_json, format_toml, parse_json, parse_toml};
 
+/// Parse a file by automatically detecting its format from extension
+///
+/// # Arguments
+/// * `path` - Path to the file to parse
+///
+/// # Returns
+/// * `Result<Value>` - The parsed value or an error
+///
+/// # Format Detection
+/// - Files ending with `.json` are parsed as JSON
+/// - Files ending with `.toml` are parsed as TOML
+/// - Other extensions will return an error
+///
+/// # Example
+/// ```no_run
+/// use zparse::{parse_file, error::Result};
+///
+/// fn example() -> Result<()> {
+///     let value = parse_file("config.json")?;
+///     println!("Parsed value: {}", value);
+///     Ok(())
+/// }
+/// ```
 #[instrument]
 pub fn parse_file(path: &str) -> Result<Value> {
     debug!("Starting to parse file: {}", path);
@@ -54,4 +111,101 @@ pub fn parse_file(path: &str) -> Result<Value> {
 
     debug!("Parsing completed");
     result
+}
+
+/// Extended capabilities for Value objects
+pub trait ValueExt {
+    /// Gets a string value from a map by key
+    ///
+    /// # Returns
+    /// Some(string) if the key exists and value is a string, None otherwise
+    fn get_string(&self, key: &str) -> Option<String>;
+
+    /// Gets a number value from a map by key
+    ///
+    /// # Returns
+    /// Some(number) if the key exists and value is a number, None otherwise
+    fn get_number(&self, key: &str) -> Option<f64>;
+
+    /// Gets a boolean value from a map by key
+    ///
+    /// # Returns
+    /// Some(bool) if the key exists and value is a boolean, None otherwise
+    fn get_bool(&self, key: &str) -> Option<bool>;
+
+    /// Gets a map value from a map by key
+    ///
+    /// # Returns
+    /// Some(map) if the key exists and value is a map, None otherwise
+    fn get_map(&self, key: &str) -> Option<&Value>;
+
+    /// Gets an array value from a map by key
+    ///
+    /// # Returns
+    /// Some(array) if the key exists and value is an array, None otherwise
+    fn get_array(&self, key: &str) -> Option<&Value>;
+}
+
+impl ValueExt for Value {
+    fn get_string(&self, key: &str) -> Option<String> {
+        match self {
+            Self::Map(map) => map.get(key).and_then(|v| {
+                if let Self::String(s) = v {
+                    Some(s.clone())
+                } else {
+                    None
+                }
+            }),
+            _ => None,
+        }
+    }
+
+    fn get_number(&self, key: &str) -> Option<f64> {
+        match self {
+            Self::Map(map) => map.get(key).and_then(|v| {
+                if let Self::Number(n) = v {
+                    Some(*n)
+                } else {
+                    None
+                }
+            }),
+            _ => None,
+        }
+    }
+
+    fn get_bool(&self, key: &str) -> Option<bool> {
+        match self {
+            Self::Map(map) => map.get(key).and_then(|v| {
+                if let Self::Boolean(b) = v {
+                    Some(*b)
+                } else {
+                    None
+                }
+            }),
+            _ => None,
+        }
+    }
+
+    fn get_map(&self, key: &str) -> Option<&Value> {
+        match self {
+            Self::Map(map) => {
+                map.get(key)
+                    .and_then(|v| if let Self::Map(_) = v { Some(v) } else { None })
+            }
+            _ => None,
+        }
+    }
+
+    fn get_array(&self, key: &str) -> Option<&Value> {
+        match self {
+            Self::Map(map) => map.get(key).and_then(|v| {
+                if let Self::Array(_) = v {
+                    Some(v)
+                } else {
+                    None
+                }
+            }),
+            _ => None,
+        }
+    }
 }

--- a/zparse/src/main.rs
+++ b/zparse/src/main.rs
@@ -73,8 +73,8 @@ fn run() -> Result<()> {
     // Handle conversion if requested
     let (final_value, output_format) = if let Some(convert_to) = args.convert {
         match (input_ext, convert_to.as_str()) {
-            ("json", "toml") => (Converter::json_to_toml(parsed_value)?, "toml"),
-            ("toml", "json") => (Converter::toml_to_json(parsed_value)?, "json"),
+            ("json", "toml") => (Converter::json_to_toml(&parsed_value)?, "toml"),
+            ("toml", "json") => (Converter::toml_to_json(&parsed_value)?, "json"),
             _ => {
                 return Err(ParseError::new(ParseErrorKind::Syntax(
                     SyntaxError::InvalidValue("conversion".to_string()),

--- a/zparse/src/parser/config.rs
+++ b/zparse/src/parser/config.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use crate::error::{ParseError, ParseErrorKind, Result, SecurityError};
 
 /// Maximum nesting depth (32) based on common JSON/TOML usage patterns
@@ -37,6 +39,16 @@ impl Default for ParserConfig {
             max_string_length: DEFAULT_MAX_STRING_LENGTH,
             max_object_entries: DEFAULT_MAX_OBJECT_ENTRIES,
         }
+    }
+}
+
+impl fmt::Display for ParserConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "ParserConfig {{ max_depth: {}, max_size: {}, max_string_length: {}, max_object_entries: {} }}",
+            self.max_depth, self.max_size, self.max_string_length, self.max_object_entries
+        )
     }
 }
 

--- a/zparse/src/parser/value.rs
+++ b/zparse/src/parser/value.rs
@@ -25,6 +25,164 @@ pub enum Value {
     DateTime(String),
 }
 
+impl Value {
+    /// Creates a null value
+    #[must_use]
+    pub fn null() -> Self {
+        Self::Null
+    }
+
+    /// Creates a boolean value
+    #[must_use]
+    pub fn boolean(value: bool) -> Self {
+        Self::Boolean(value)
+    }
+
+    /// Creates a number value
+    #[must_use]
+    pub fn number(value: f64) -> Self {
+        Self::Number(value)
+    }
+
+    /// Creates a string value
+    #[must_use]
+    pub fn string(value: impl Into<String>) -> Self {
+        Self::String(value.into())
+    }
+
+    /// Creates an array value
+    #[must_use]
+    pub fn array(values: Vec<Self>) -> Self {
+        Self::Array(values)
+    }
+
+    /// Creates a map/object value
+    #[must_use]
+    pub fn map(entries: HashMap<String, Self>) -> Self {
+        Self::Map(entries)
+    }
+
+    /// Creates a datetime value (TOML only)
+    #[must_use]
+    pub fn datetime(value: impl Into<String>) -> Self {
+        Self::DateTime(value.into())
+    }
+
+    /// Returns true if this value is null
+    #[must_use]
+    pub fn is_null(&self) -> bool {
+        matches!(self, Self::Null)
+    }
+
+    /// Returns true if this value is a boolean
+    #[must_use]
+    pub fn is_boolean(&self) -> bool {
+        matches!(self, Self::Boolean(_))
+    }
+
+    /// Returns true if this value is a number
+    #[must_use]
+    pub fn is_number(&self) -> bool {
+        matches!(self, Self::Number(_))
+    }
+
+    /// Returns true if this value is a string
+    #[must_use]
+    pub fn is_string(&self) -> bool {
+        matches!(self, Self::String(_))
+    }
+
+    /// Returns true if this value is an array
+    #[must_use]
+    pub fn is_array(&self) -> bool {
+        matches!(self, Self::Array(_))
+    }
+
+    /// Returns true if this value is a map/object
+    #[must_use]
+    pub fn is_map(&self) -> bool {
+        matches!(self, Self::Map(_))
+    }
+
+    /// Returns true if this value is a datetime
+    #[must_use]
+    pub fn is_datetime(&self) -> bool {
+        matches!(self, Self::DateTime(_))
+    }
+
+    /// Returns the value as a boolean, if it is a boolean
+    #[must_use]
+    pub fn as_boolean(&self) -> Option<bool> {
+        match self {
+            Self::Boolean(b) => Some(*b),
+            _ => None,
+        }
+    }
+
+    /// Returns the value as a number, if it is a number
+    #[must_use]
+    pub fn as_number(&self) -> Option<f64> {
+        match self {
+            Self::Number(n) => Some(*n),
+            _ => None,
+        }
+    }
+
+    /// Returns a reference to the string, if this value is a string
+    #[must_use]
+    pub fn as_string(&self) -> Option<&str> {
+        match self {
+            Self::String(s) => Some(s),
+            _ => None,
+        }
+    }
+
+    /// Returns a reference to the array, if this value is an array
+    #[must_use]
+    pub fn as_array(&self) -> Option<&[Self]> {
+        match self {
+            Self::Array(arr) => Some(arr),
+            _ => None,
+        }
+    }
+
+    /// Returns a mutable reference to the array, if this value is an array
+    #[must_use]
+    pub fn as_array_mut(&mut self) -> Option<&mut Vec<Self>> {
+        match self {
+            Self::Array(arr) => Some(arr),
+            _ => None,
+        }
+    }
+
+    /// Returns a reference to the map, if this value is a map
+    #[must_use]
+    pub fn as_map(&self) -> Option<&HashMap<String, Self>> {
+        match self {
+            Self::Map(map) => Some(map),
+            _ => None,
+        }
+    }
+
+    /// Returns a mutable reference to the map, if this value is a map
+    #[must_use]
+    pub fn as_map_mut(&mut self) -> Option<&mut HashMap<String, Self>> {
+        match self {
+            Self::Map(map) => Some(map),
+            _ => None,
+        }
+    }
+
+    /// Returns a reference to the datetime string, if this value is a datetime
+    #[must_use]
+    pub fn as_datetime(&self) -> Option<&str> {
+        match self {
+            Self::DateTime(dt) => Some(dt),
+            _ => None,
+        }
+    }
+}
+
 impl fmt::Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -57,7 +215,8 @@ impl fmt::Display for Value {
     }
 }
 
-// Helper function to compare values structurally rather than string representation
+/// Helper function to compare values structurally rather than string representation
+#[must_use]
 pub fn values_equal(left: &Value, right: &Value) -> bool {
     match (left, right) {
         (Value::Map(l_map), Value::Map(r_map)) => {

--- a/zparse/tests/conversion_tests.rs
+++ b/zparse/tests/conversion_tests.rs
@@ -11,7 +11,7 @@ fn test_json_to_toml_conversion() -> Result<()> {
 
     let mut json_parser = JsonParser::new(&test_data.medium_json)?;
     let json_value = json_parser.parse()?;
-    let toml_value = Converter::json_to_toml(json_value.clone())?;
+    let toml_value = Converter::json_to_toml(&json_value)?;
 
     let mut toml_parser = TomlParser::new(&test_data.medium_toml)?;
     let expected_value = toml_parser.parse()?;
@@ -30,7 +30,7 @@ fn test_toml_to_json_conversion() -> Result<()> {
 
     let mut toml_parser = TomlParser::new(&test_data.medium_toml)?;
     let toml_value = toml_parser.parse()?;
-    let json_value = Converter::toml_to_json(toml_value.clone())?;
+    let json_value = Converter::toml_to_json(&toml_value)?;
 
     let mut json_parser = JsonParser::new(&test_data.medium_json)?;
     let expected_value = json_parser.parse()?;
@@ -99,8 +99,8 @@ fn test_json_toml_json_roundtrip() -> Result<()> {
     let mut original_json = JsonParser::new(&test_data.medium_json)?;
     let json_value = original_json.parse()?;
 
-    let toml_value = Converter::json_to_toml(json_value.clone())?;
-    let converted_back = Converter::toml_to_json(toml_value.clone())?;
+    let toml_value = Converter::json_to_toml(&json_value)?;
+    let converted_back = Converter::toml_to_json(&toml_value)?;
 
     assert_values_equal(
         &toml_value,
@@ -118,8 +118,8 @@ fn test_toml_json_toml_roundtrip() -> Result<()> {
     let mut original_toml = TomlParser::new(&test_data.medium_toml)?;
     let toml_value = original_toml.parse()?;
 
-    let json_value = Converter::toml_to_json(toml_value.clone())?;
-    let converted_back = Converter::json_to_toml(json_value.clone())?;
+    let json_value = Converter::toml_to_json(&toml_value)?;
+    let converted_back = Converter::json_to_toml(&json_value)?;
 
     assert_values_equal(
         &json_value,
@@ -136,7 +136,7 @@ fn converter_null_value_error() {
     // because TOML does not support null values.
     let input = r#"{"key": null}"#;
     let json_value = parse_json(input).expect("JSON should parse successfully");
-    let result = Converter::json_to_toml(json_value);
+    let result = Converter::json_to_toml(&json_value);
     assert!(result.is_err(), "Expected converter error for null value");
 
     let err = result.unwrap_err();
@@ -157,7 +157,7 @@ fn converter_null_value_error() {
 fn test_array_with_null_conversion() {
     let input = r#"{"array": [1, null, 3]}"#;
     let json_value = parse_json(input).expect("JSON should parse successfully");
-    let result = Converter::json_to_toml(json_value);
+    let result = Converter::json_to_toml(&json_value);
     assert!(result.is_err(), "Expected error for array containing null");
 
     let err = result.unwrap_err();
@@ -180,7 +180,7 @@ fn test_array_with_null_conversion() {
 fn test_error_location_tracking() -> Result<()> {
     let input = r#"{"key": null}"#; // Invalid TOML value
     let json_value = parse_json(input)?;
-    let result = Converter::json_to_toml(json_value);
+    let result = Converter::json_to_toml(&json_value);
 
     assert!(result.is_err());
     let err = result.unwrap_err();
@@ -213,7 +213,7 @@ fn test_nested_location_tracking() -> Result<()> {
         }
     }"#;
     let json_value = parse_json(input)?;
-    let result = Converter::json_to_toml(json_value);
+    let result = Converter::json_to_toml(&json_value);
 
     assert!(result.is_err());
     let err = result.unwrap_err();

--- a/zparse/tests/json_tests.rs
+++ b/zparse/tests/json_tests.rs
@@ -195,7 +195,7 @@ mod json_tests {
 
         let mut parser = JsonParser::new(input)?;
         let json_value = parser.parse()?;
-        let toml_value = Converter::json_to_toml(json_value)?;
+        let toml_value = Converter::json_to_toml(&json_value)?;
 
         // Verify the conversion maintained the structure
         if let Value::Map(root) = toml_value {

--- a/zparse/tests/property_tests.rs
+++ b/zparse/tests/property_tests.rs
@@ -57,8 +57,8 @@ proptest! {
 
         let mut parser = JsonParser::new(&json_str).unwrap();
         let original = parser.parse().unwrap();
-        let toml = Converter::json_to_toml(original.clone()).unwrap();
-        let back_to_json = Converter::toml_to_json(toml).unwrap();
+        let toml = Converter::json_to_toml(&original).unwrap();
+        let back_to_json = Converter::toml_to_json(&toml).unwrap();
 
         prop_assert!(values_equal(&original, &back_to_json));
     }
@@ -91,8 +91,8 @@ proptest! {
 
         let mut parser = JsonParser::new(&json_str).unwrap();
         let original = parser.parse().unwrap();
-        let toml = Converter::json_to_toml(original.clone()).unwrap();
-        let back_to_json = Converter::toml_to_json(toml).unwrap();
+        let toml = Converter::json_to_toml(&original).unwrap();
+        let back_to_json = Converter::toml_to_json(&toml).unwrap();
 
         prop_assert!(values_equal(&original, &back_to_json));
     }
@@ -125,8 +125,8 @@ proptest! {
         for case in edge_cases {
             let mut parser = JsonParser::new(&case).unwrap();
             let original = parser.parse().unwrap();
-            let toml = Converter::json_to_toml(original.clone()).unwrap();
-            let back_to_json = Converter::toml_to_json(toml).unwrap();
+            let toml = Converter::json_to_toml(&original).unwrap();
+            let back_to_json = Converter::toml_to_json(&toml).unwrap();
 
             prop_assert!(values_equal(&original, &back_to_json));
         }
@@ -147,8 +147,8 @@ proptest! {
 
         let mut parser = JsonParser::new(&json_str).unwrap();
         let original = parser.parse().unwrap();
-        let toml = Converter::json_to_toml(original.clone()).unwrap();
-        let back_to_json = Converter::toml_to_json(toml).unwrap();
+        let toml = Converter::json_to_toml(&original).unwrap();
+        let back_to_json = Converter::toml_to_json(&toml).unwrap();
 
         prop_assert!(values_equal(&original, &back_to_json));
     }
@@ -186,8 +186,8 @@ proptest! {
 
         let mut parser = JsonParser::new(&json_str).unwrap();
         let original = parser.parse().unwrap();
-        let toml = Converter::json_to_toml(original.clone()).unwrap();
-        let back_to_json = Converter::toml_to_json(toml).unwrap();
+        let toml = Converter::json_to_toml(&original).unwrap();
+        let back_to_json = Converter::toml_to_json(&toml).unwrap();
 
         prop_assert!(values_equal(&original, &back_to_json));
     }
@@ -215,8 +215,8 @@ proptest! {
 
         let mut parser = JsonParser::new(&json_str).unwrap();
         let original = parser.parse().unwrap();
-        let toml = Converter::json_to_toml(original.clone()).unwrap();
-        let back_to_json = Converter::toml_to_json(toml).unwrap();
+        let toml = Converter::json_to_toml(&original).unwrap();
+        let back_to_json = Converter::toml_to_json(&toml).unwrap();
 
         prop_assert!(values_equal(&original, &back_to_json));
     }
@@ -256,8 +256,8 @@ proptest! {
 
         let mut parser = JsonParser::new(&json_str).unwrap();
         let original = parser.parse().unwrap();
-        let toml = Converter::json_to_toml(original.clone()).unwrap();
-        let back_to_json = Converter::toml_to_json(toml).unwrap();
+        let toml = Converter::json_to_toml(&original).unwrap();
+        let back_to_json = Converter::toml_to_json(&toml).unwrap();
 
         prop_assert!(values_equal(&original, &back_to_json));
     }

--- a/zparse/tests/toml_tests.rs
+++ b/zparse/tests/toml_tests.rs
@@ -276,7 +276,7 @@ mod toml_tests {
 
         let mut parser = TomlParser::new(input)?;
         let toml_value = parser.parse()?;
-        let json_value = Converter::toml_to_json(toml_value)?;
+        let json_value = Converter::toml_to_json(&toml_value)?;
 
         // Verify the conversion maintained the structure
         if let Value::Map(root) = json_value {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

- update the `cargo.toml` to follow `crates.io` guidelines
- use reference instead of cloning where ever possible
- implement standard error to custom error and use `from` and `tryfrom`
- use stricter `Value`s

## Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

close https://github.com/pixincreate/zParse/pull/23

i made a mistake. i made all the refactoring on single branch, committed at the end into different branches. 

i want to standardise the code. following rust api guidelines: https://rust-lang.github.io/api-guidelines/print.html

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
