### PR TITLE
ci: refactor the release pipeline to make it more streamlined

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  # Enable version updates for npm
+  # Enable version updates for cargo 
   - package-ecosystem: "cargo"
     # Look for `Cargo.toml` and `Cargo.lock` files in the `root` directory
     directory: "/"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
         run: cargo clippy --package zparse --all-features --all-targets
 
   docs:
-    name: Docs
+    name: documentation
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,10 @@ concurrency:
 env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
+  CARGO_TERM_COLOR: always
   RUSTUP_MAX_RETRIES: 10
   RUST_BACKTRACE: short
+  RUSTFLAGS: "-D warnings" # Treat warnings as errors
 
 jobs:
   formatting:
@@ -34,9 +36,32 @@ jobs:
           toolchain: nightly
           components: rustfmt
 
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.event_name == 'push' }}
+
       - name: Check formatting
         shell: bash
         run: cargo +nightly fmt --all --check
+
+  security-audit:
+    name: security-audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit
+
+      - name: Run security audit
+        run: cargo audit
 
   typos:
     name: spell-check
@@ -77,7 +102,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable 2 weeks ago
+          toolchain: stable
           components: clippy
 
       - uses: Swatinem/rust-cache@v2.7.0
@@ -92,4 +117,30 @@ jobs:
         run: cargo test --package zparse --release --all-features --all-targets
 
       - name: Run Clippy
-        run: cargo clippy --package zparse --all-features --all-targets -- -D warnings
+        run: cargo clippy --package zparse --all-features --all-targets
+
+  docs:
+    name: Docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly
+          components: rustfmt
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.event_name == 'push' }}
+
+      - name: Check documentation
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+        run: cargo doc --no-deps --document-private-items
+
+      - name: Run doctests
+        run: cargo test --doc --package zparse

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,78 @@ env:
   PROJECT_NAME: "zparse"
 
 jobs:
-  release:
+  prepare-release:
+    name: Prepare Release
+    runs-on: ubuntu-latest
+    outputs:
+      commit_sha: ${{ steps.commit-changes.outputs.commit_sha }}
+      version: ${{ steps.get-version.outputs.version }}
+    steps:
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.NERDY_ID }}
+          private-key: ${{ secrets.NERDY_SECRET }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
+
+      - name: Configure Git
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Extract version from tag
+        id: get-version
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+
+          if ! [[ $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9\.]+)?$ ]]; then
+            echo "::error::Invalid version format: $VERSION. Expected semantic versioning (e.g., 1.2.3 or 1.2.3-alpha.1)"
+            exit 1
+          fi
+
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Processing version: $VERSION"
+
+      - name: Update version in Cargo.toml
+        run: |
+          sed -i.bak "s/^version = .*/version = \"$VERSION\"/" Cargo.toml
+          rm Cargo.toml.bak  # Clean up backup file
+
+          echo "Updated version in Cargo.toml to $VERSION"
+
+      - name: Update CHANGELOG.md
+        run: |
+          DATE=$(date +%Y-%m-%d)
+
+          # Verify CHANGELOG.md has expected format
+          if ! grep -q "## \[Unreleased\]" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md doesn't contain expected '## [Unreleased]' section"
+            exit 1
+          fi
+
+          sed -i.bak "s/## \[Unreleased\]/## [Unreleased]\n\n## [$VERSION] - $DATE/" CHANGELOG.md
+          rm CHANGELOG.md.bak  # Clean up backup file
+
+          echo "Updated CHANGELOG.md with new version $VERSION and date $DATE"
+
+      - name: Commit changes to main
+        id: commit-changes
+        run: |
+          git add Cargo.toml CHANGELOG.md
+          git commit -m "release(zParse): version $VERSION [skip ci]"
+          git push origin HEAD:main
+          echo "commit_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
+  build-and-release:
+    needs: prepare-release
     name: release-${{ matrix.platform.asset_name }}
     runs-on: ${{ matrix.platform.os }}
     strategy:
@@ -36,20 +107,29 @@ jobs:
             target: x86_64-pc-windows-msvc
             asset_name: windows
             arch: x86_64
-    env:
-      BINARY_NAME: ${{ env.PROJECT_NAME }}-${{ matrix.platform.asset_name }}-${{ matrix.platform.arch }}${{ matrix.platform.os == 'windows-latest' && '.exe' || '' }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ needs.prepare-release.outputs.commit_sha }}
+
+      - name: Set binary name
+        id: binary
+        shell: bash
+        run: |
+          if [ "${{ matrix.platform.os }}" = "windows-latest" ]; then
+            echo "name=${{ env.PROJECT_NAME }}-${{ matrix.platform.asset_name }}-${{ matrix.platform.arch }}.exe" >> $GITHUB_OUTPUT
+          else
+            echo "name=${{ env.PROJECT_NAME }}-${{ matrix.platform.asset_name }}-${{ matrix.platform.arch }}" >> $GITHUB_OUTPUT
+          fi
 
       - name: Extract Release Notes
         id: release-notes
         if: matrix.platform.os == 'ubuntu-latest'
         run: |
-          VERSION=${GITHUB_REF#refs/tags/}
+          VERSION=${needs.prepare-release.outputs.version}
           NOTES=$(awk -v ver="$VERSION" '
             /^## \[/ { if (p) { exit }; if ($2 == "['ver']") { p=1; next } }
             p { print }
@@ -91,16 +171,30 @@ jobs:
         run: |
           mkdir -p release
           cp target/${{ matrix.platform.target }}/release/${{ env.PROJECT_NAME }}${{ matrix.platform.os == 'windows-latest' && '.exe' || '' }} \
-             release/${{ env.BINARY_NAME }}
+            release/${{ steps.binary.outputs.name }}
+
+      - name: Smoke test binary
+        shell: bash
+        run: |
+          ./release/${{ steps.binary.outputs.name }} --help || ./release/${{ steps.binary.outputs.name }} -h || true
+
+          # Verify binary exists and has proper permissions
+          if [ ! -f "release/${{ steps.binary.outputs.name }}" ]; then
+            echo "::error::Binary not found after build"
+            exit 1
+          fi
+
+          if [ "${{ matrix.platform.os }}" != "windows-latest" ]; then
+            chmod +x "release/${{ steps.binary.outputs.name }}"
+          fi
 
       # Create checksum
       - name: Generate SHA-256
         run: |
-          cd release
           if [ "${{ matrix.platform.os }}" = "windows-latest" ]; then
-            certutil -hashfile ${{ env.BINARY_NAME }} SHA256 | grep -v "hash" > ${{ env.BINARY_NAME }}.sha256
+            certutil -hashfile release/${{ steps.binary.outputs.name }} SHA256 | grep -v "hash" > release/${{ steps.binary.outputs.name }}.sha256
           else
-            shasum -a 256 ${{ env.BINARY_NAME }} > ${{ env.BINARY_NAME }}.sha256
+            shasum -a 256 release/${{ steps.binary.outputs.name }} > release/${{ steps.binary.outputs.name }}.sha256
           fi
 
       # Sign the artifacts
@@ -112,7 +206,7 @@ jobs:
           echo "$SSH_KEY" > ~/.ssh/id_signing
           chmod 600 ~/.ssh/id_signing
           cd release
-          ssh-keygen -Y sign -f ~/.ssh/id_signing -n file "${{ env.BINARY_NAME }}"
+          ssh-keygen -Y sign -f ~/.ssh/id_signing -n file "${{ steps.binary.outputs.name }}"
           rm ~/.ssh/id_signing
 
       # Create Release
@@ -121,9 +215,9 @@ jobs:
         with:
           name: "zParse ${{ github.ref_name }}"
           files: |
-            release/${{ env.BINARY_NAME }}
-            release/${{ env.BINARY_NAME }}.sha256
-            release/${{ env.BINARY_NAME }}.sig
+            release/${{ steps.binary.outputs.name }}
+            release/${{ steps.binary.outputs.name }}.sha256
+            release/${{ steps.binary.outputs.name }}.sig
           body: ${{ steps.release-notes.outputs.NOTES }}
           draft: false
           prerelease: false


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->

reference: https://github.com/orgs/community/discussions/25305#discussioncomment-8256560

Existing release script are a complicated and messed up. The problem with current set up is as below:

- Current one
	- You create and push a tag to the main branch directly with updated `Cargo.toml` and `CHANGELOG.md`
	- It fails due to branch protection rules
- Another one
	- You checkout to release branch, commit and push the changes
	- You create a tag against main branch
	- Release happens on main branch
	- You manually raise a PR updating the `Cargo.toml` and `CHANGELOG.md`

This is just too inconvenient. At least for me. To address this, below is what is done in this PR:

- Created a GitHub app called `nerdy-grapes`
- Gave it the permissions to merge to main
- Updates to release script to only push and delete tags
- Updates to `release.yml` to make changes to `Cargo.toml` and `CHANGELOG.md` and commit directly to main

## Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

Release `v1.1.0` got delayed due to this

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Upcoming release should happen without any issues

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
