### PR TITLE
feat(csv): add custom delimiter support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@
 - Add bidirectional conversion support for CSV with JSON, TOML, YAML, and XML
 - Add JSONC-compatible conversion paths by accepting comments/trailing commas on JSON input and normalizing output
 - Add `zparse-wasm` crate with browser/Node-compatible `convert`, `parse`, and `detect_format` APIs via `wasm-bindgen`
-- Add CSV custom delimiter support via `from_csv_str_with_delimiter` and `from_csv_bytes_with_delimiter` APIs
+- Add CSV custom delimiter support via `from_csv_str_with_delimiter` and `from_csv_bytes_with_delimiter` library APIs
+- Expose `--csv-delimiter` flag on CLI `parse` and `convert` subcommands (and top-level `--parse`/`--convert` flags)
+- Add `convert_csv(input, to, delimiter)` and `parse_csv_delimiter(input, delimiter)` exports to `zparse-wasm`
 
 ### Refactor
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add bidirectional conversion support for CSV with JSON, TOML, YAML, and XML
 - Add JSONC-compatible conversion paths by accepting comments/trailing commas on JSON input and normalizing output
 - Add `zparse-wasm` crate with browser/Node-compatible `convert`, `parse`, and `detect_format` APIs via `wasm-bindgen`
+- Add CSV custom delimiter support via `from_csv_str_with_delimiter` and `from_csv_bytes_with_delimiter` APIs
 
 ### Refactor
 

--- a/README.md
+++ b/README.md
@@ -17,13 +17,16 @@ zParse is a high-performance Rust library and toolchain for parsing and converti
 ### Library
 
 ```rust
-use zparse::{from_csv_str, from_str, from_toml_str, from_yaml_str, from_xml_str};
+use zparse::{from_csv_str, from_csv_str_with_delimiter, from_str, from_toml_str, from_yaml_str, from_xml_str};
 
 let json_value = from_str(r#"{"name": "zparse"}"#)?;
 let toml_value = from_toml_str("name = \"zparse\"\n")?;
 let yaml_value = from_yaml_str("name: zparse\n")?;
 let xml_doc = from_xml_str("<root><name>zparse</name></root>")?;
 let csv_value = from_csv_str("name,age\nzparse,2\n")?;
+
+// Custom CSV delimiter (semicolon, tab, pipe, etc.)
+let tsv_value = from_csv_str_with_delimiter("name\tage\nzparse\t2\n", b'\t')?;
 # Ok::<(), zparse::Error>(())
 ```
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ zparse convert --from json --to toml input.json
 # Convert CSV to JSON
 zparse convert --from csv --to json input.csv
 
+# Parse a TSV file (tab-separated values)
+zparse parse --from csv --csv-delimiter $'\t' input.tsv
+
+# Convert a pipe-delimited CSV to JSON
+zparse convert --from csv --to json --csv-delimiter '|' input.csv
+
 # Convert TOML to YAML with format inference for the input
 zparse convert --to yaml input.toml
 
@@ -139,13 +145,16 @@ wasm-pack test --node crates/zparse-wasm
 Use from JavaScript:
 
 ```js
-import init, { convert, parse, detect_format } from "./pkg/zparse_wasm.js";
+import init, { convert, parse, detect_format, convert_csv } from "./pkg/zparse_wasm.js";
 
 await init();
 
 const toml = convert('{"name":"zparse"}', "json", "toml");
 const json = parse("name = \"zparse\"", "toml");
 const fmt = detect_format("data.csv"); // "csv"
+
+// Custom CSV delimiter (e.g. tab-separated)
+const tsvJson = convert_csv("name\tage\nzparse\t2", "json", "\t");
 ```
 
 ## Contribution

--- a/crates/zparse-api/src/main.rs
+++ b/crates/zparse-api/src/main.rs
@@ -133,7 +133,10 @@ async fn convert(Json(payload): Json<ConvertRequest>) -> Json<ConvertResponse> {
             &payload.content,
             payload.from.into(),
             payload.to.into(),
-            &zparse::ConvertOptions { json: config },
+            &zparse::ConvertOptions {
+                json: config,
+                ..Default::default()
+            },
         )
     } else {
         zparse::convert(&payload.content, payload.from.into(), payload.to.into())
@@ -162,7 +165,10 @@ fn parse_to_json(input: &str, format: InputFormat) -> Result<serde_json::Value, 
             input,
             format.into(),
             zparse::Format::Json,
-            &zparse::ConvertOptions { json: config },
+            &zparse::ConvertOptions {
+                json: config,
+                ..Default::default()
+            },
         )
     } else {
         zparse::convert(input, format.into(), zparse::Format::Json)

--- a/crates/zparse-api/src/main.rs
+++ b/crates/zparse-api/src/main.rs
@@ -8,6 +8,7 @@ use tower_http::cors::{Any, CorsLayer};
 struct ParseRequest {
     content: String,
     format: InputFormat,
+    csv_delimiter: Option<char>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -15,6 +16,7 @@ struct ConvertRequest {
     content: String,
     from: InputFormat,
     to: OutputFormat,
+    csv_delimiter: Option<char>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, Copy)]
@@ -116,13 +118,14 @@ async fn formats() -> Json<Vec<&'static str>> {
 }
 
 async fn parse(Json(payload): Json<ParseRequest>) -> Json<ApiResponse> {
-    match parse_to_json(&payload.content, payload.format) {
+    match parse_to_json(&payload.content, payload.format, payload.csv_delimiter) {
         Ok(data) => Json(ApiResponse::Ok { data }),
         Err(err) => Json(ApiResponse::Err { error: err }),
     }
 }
 
 async fn convert(Json(payload): Json<ConvertRequest>) -> Json<ConvertResponse> {
+    let csv_config = csv_config_from_delimiter(payload.csv_delimiter);
     let result = if matches!(payload.from, InputFormat::Jsonc) {
         let config = zparse::JsonConfig {
             allow_comments: true,
@@ -135,6 +138,16 @@ async fn convert(Json(payload): Json<ConvertRequest>) -> Json<ConvertResponse> {
             payload.to.into(),
             &zparse::ConvertOptions {
                 json: config,
+                csv: csv_config,
+            },
+        )
+    } else if matches!(payload.from, InputFormat::Csv) && payload.csv_delimiter.is_some() {
+        zparse::convert_with_options(
+            &payload.content,
+            payload.from.into(),
+            payload.to.into(),
+            &zparse::ConvertOptions {
+                csv: csv_config,
                 ..Default::default()
             },
         )
@@ -154,7 +167,19 @@ async fn convert(Json(payload): Json<ConvertRequest>) -> Json<ConvertResponse> {
     }
 }
 
-fn parse_to_json(input: &str, format: InputFormat) -> Result<serde_json::Value, String> {
+fn csv_config_from_delimiter(delimiter: Option<char>) -> zparse::CsvConfig {
+    match delimiter {
+        Some(ch) if ch.is_ascii() => zparse::CsvConfig::default().with_delimiter(ch as u8),
+        _ => zparse::CsvConfig::default(),
+    }
+}
+
+fn parse_to_json(
+    input: &str,
+    format: InputFormat,
+    csv_delimiter: Option<char>,
+) -> Result<serde_json::Value, String> {
+    let csv_config = csv_config_from_delimiter(csv_delimiter);
     let json = if matches!(format, InputFormat::Jsonc) {
         let config = zparse::JsonConfig {
             allow_comments: true,
@@ -167,6 +192,16 @@ fn parse_to_json(input: &str, format: InputFormat) -> Result<serde_json::Value, 
             zparse::Format::Json,
             &zparse::ConvertOptions {
                 json: config,
+                csv: csv_config,
+            },
+        )
+    } else if matches!(format, InputFormat::Csv) && csv_delimiter.is_some() {
+        zparse::convert_with_options(
+            input,
+            format.into(),
+            zparse::Format::Json,
+            &zparse::ConvertOptions {
+                csv: csv_config,
                 ..Default::default()
             },
         )

--- a/crates/zparse-cli/src/main.rs
+++ b/crates/zparse-cli/src/main.rs
@@ -39,39 +39,17 @@ struct Args {
     /// Allow trailing commas in JSON
     #[arg(long)]
     json_trailing_commas: bool,
+    /// CSV field delimiter as a single character (default: ,)
+    #[arg(long, value_name = "CHAR")]
+    csv_delimiter: Option<char>,
 }
 
 #[derive(Debug, Subcommand)]
 enum Command {
-    /// Parse input and validate
+    /// Validate an input file or stdin
     Parse(ParseArgs),
     /// Convert between formats
     Convert(ConvertArgs),
-}
-
-impl From<FormatArg> for zparse::Format {
-    fn from(value: FormatArg) -> Self {
-        match value {
-            FormatArg::Json => zparse::Format::Json,
-            FormatArg::Jsonc => zparse::Format::Json,
-            FormatArg::Csv => zparse::Format::Csv,
-            FormatArg::Toml => zparse::Format::Toml,
-            FormatArg::Yaml => zparse::Format::Yaml,
-            FormatArg::Xml => zparse::Format::Xml,
-        }
-    }
-}
-
-impl From<OutputFormatArg> for zparse::Format {
-    fn from(value: OutputFormatArg) -> Self {
-        match value {
-            OutputFormatArg::Json => zparse::Format::Json,
-            OutputFormatArg::Csv => zparse::Format::Csv,
-            OutputFormatArg::Toml => zparse::Format::Toml,
-            OutputFormatArg::Yaml => zparse::Format::Yaml,
-            OutputFormatArg::Xml => zparse::Format::Xml,
-        }
-    }
 }
 
 #[derive(Debug, Parser)]
@@ -94,6 +72,9 @@ struct ParseArgs {
     /// Allow trailing commas in JSON
     #[arg(long)]
     json_trailing_commas: bool,
+    /// CSV field delimiter as a single character (default: ,)
+    #[arg(long, value_name = "CHAR")]
+    csv_delimiter: Option<char>,
 }
 
 #[derive(Debug, Parser)]
@@ -119,6 +100,9 @@ struct ConvertArgs {
     /// Allow trailing commas in JSON
     #[arg(long)]
     json_trailing_commas: bool,
+    /// CSV field delimiter as a single character (default: ,)
+    #[arg(long, value_name = "CHAR")]
+    csv_delimiter: Option<char>,
 }
 
 #[derive(Clone, Debug, ValueEnum)]
@@ -142,6 +126,30 @@ enum OutputFormatArg {
     Xml,
 }
 
+impl From<FormatArg> for zparse::Format {
+    fn from(value: FormatArg) -> Self {
+        match value {
+            FormatArg::Json | FormatArg::Jsonc => zparse::Format::Json,
+            FormatArg::Csv => zparse::Format::Csv,
+            FormatArg::Toml => zparse::Format::Toml,
+            FormatArg::Yaml => zparse::Format::Yaml,
+            FormatArg::Xml => zparse::Format::Xml,
+        }
+    }
+}
+
+impl From<OutputFormatArg> for zparse::Format {
+    fn from(value: OutputFormatArg) -> Self {
+        match value {
+            OutputFormatArg::Json => zparse::Format::Json,
+            OutputFormatArg::Csv => zparse::Format::Csv,
+            OutputFormatArg::Toml => zparse::Format::Toml,
+            OutputFormatArg::Yaml => zparse::Format::Yaml,
+            OutputFormatArg::Xml => zparse::Format::Xml,
+        }
+    }
+}
+
 fn main() -> Result<()> {
     let args = Args::parse();
     if let Some(command) = args.command {
@@ -159,6 +167,7 @@ fn main() -> Result<()> {
             print_output: args.print_output,
             json_comments: args.json_comments,
             json_trailing_commas: args.json_trailing_commas,
+            csv_delimiter: args.csv_delimiter,
         };
         return run_parse(parse_args);
     }
@@ -175,6 +184,7 @@ fn main() -> Result<()> {
             print_output: args.print_output,
             json_comments: args.json_comments,
             json_trailing_commas: args.json_trailing_commas,
+            csv_delimiter: args.csv_delimiter,
         };
         return run_convert(convert_args);
     }
@@ -194,7 +204,8 @@ fn run_parse(args: ParseArgs) -> Result<()> {
             parser.parse_value()?;
         }
         zparse::Format::Csv => {
-            let mut parser = zparse::csv::Parser::new(input_data.as_bytes());
+            let config = csv_config_from_flags(args.csv_delimiter)?;
+            let mut parser = zparse::csv::Parser::with_config(input_data.as_bytes(), config);
             parser.parse()?;
         }
         zparse::Format::Toml => {
@@ -224,7 +235,11 @@ fn run_convert(args: ConvertArgs) -> Result<()> {
     let (from, is_jsonc) = resolve_format(args.from, &args.input)?;
     let json_config =
         json_config_from_flags(is_jsonc, args.json_comments, args.json_trailing_commas);
-    let options = zparse::ConvertOptions { json: json_config };
+    let csv_config = csv_config_from_flags(args.csv_delimiter)?;
+    let options = zparse::ConvertOptions {
+        json: json_config,
+        csv: csv_config,
+    };
     let to = args.to.into();
     let output = zparse::convert_with_options(&input_data, from, to, &options)?;
 
@@ -329,4 +344,23 @@ fn json_config_from_flags(
     }
 
     config
+}
+
+fn csv_config_from_flags(delimiter: Option<char>) -> Result<zparse::CsvConfig> {
+    match delimiter {
+        None => Ok(zparse::CsvConfig::default()),
+        Some(ch) => {
+            if !ch.is_ascii() {
+                bail!("CSV delimiter must be an ASCII character");
+            }
+            let byte = ch as u8;
+            if matches!(byte, b'\n' | b'\r' | b'"') {
+                bail!(
+                    "CSV delimiter {:?} conflicts with record separators or quoting rules",
+                    ch
+                );
+            }
+            Ok(zparse::CsvConfig::default().with_delimiter(byte))
+        }
+    }
 }

--- a/crates/zparse-wasm/src/lib.rs
+++ b/crates/zparse-wasm/src/lib.rs
@@ -110,6 +110,26 @@ pub fn convert(input: &str, from: &str, to: &str) -> Result<String, JsValue> {
         .map_err(|e| serialize_to_js(&JsError::from(e)))
 }
 
+/// Convert CSV with a custom delimiter to another format
+/// - input: the CSV input string
+/// - to: target format ("json", "csv", "toml", "yaml", "xml")
+/// - delimiter: single ASCII character used as field separator (e.g. ";" or "\t")
+/// Returns converted string or throws error
+#[wasm_bindgen]
+pub fn convert_csv(input: &str, to: &str, delimiter: &str) -> Result<String, JsValue> {
+    let to_format = parse_format(to).map_err(|e| serialize_to_js(&e))?;
+
+    let delim_byte = parse_csv_delimiter(delimiter).map_err(|e| serialize_to_js(&e))?;
+    let csv_config = zparse::CsvConfig::default().with_delimiter(delim_byte);
+    let options = zparse::ConvertOptions {
+        csv: csv_config,
+        ..Default::default()
+    };
+
+    zparse::convert_with_options(input, zparse::Format::Csv, to_format, &options)
+        .map_err(|e| serialize_to_js(&JsError::from(e)))
+}
+
 /// Parse content to JSON
 /// - content: the input string
 /// - format: source format ("json", "csv", "toml", "yaml", "xml")
@@ -154,6 +174,41 @@ fn parse_format(s: &str) -> Result<Format, JsError> {
         "xml" => Ok(Format::Xml),
         _ => Err(JsError::unknown_format(s)),
     }
+}
+
+fn parse_csv_delimiter(s: &str) -> Result<u8, JsError> {
+    let mut chars = s.chars();
+    let ch = chars.next().ok_or_else(|| JsError {
+        kind: "InvalidToken".to_string(),
+        message: "CSV delimiter must be a single ASCII character".to_string(),
+        span: None,
+    })?;
+    if chars.next().is_some() {
+        return Err(JsError {
+            kind: "InvalidToken".to_string(),
+            message: "CSV delimiter must be a single character".to_string(),
+            span: None,
+        });
+    }
+    if !ch.is_ascii() {
+        return Err(JsError {
+            kind: "InvalidToken".to_string(),
+            message: "CSV delimiter must be an ASCII character".to_string(),
+            span: None,
+        });
+    }
+    let byte = ch as u8;
+    if matches!(byte, b'\n' | b'\r' | b'"') {
+        return Err(JsError {
+            kind: "InvalidToken".to_string(),
+            message: format!(
+                "CSV delimiter {:?} conflicts with record separators or quoting rules",
+                ch
+            ),
+            span: None,
+        });
+    }
+    Ok(byte)
 }
 
 #[cfg(test)]

--- a/crates/zparse/src/convert.rs
+++ b/crates/zparse/src/convert.rs
@@ -1,8 +1,8 @@
 //! Format conversion utilities
 
+use crate::csv::Parser as CsvParser;
 use crate::csv::infer_primitive_value;
 use crate::csv::parser::Config as CsvConfig;
-use crate::csv::Parser as CsvParser;
 use crate::error::{Error, ErrorKind, Result, Span};
 use crate::json::{Config as JsonConfig, Parser as JsonParser};
 use crate::toml::Parser as TomlParser;

--- a/crates/zparse/src/convert.rs
+++ b/crates/zparse/src/convert.rs
@@ -1,7 +1,8 @@
 //! Format conversion utilities
 
-use crate::csv::Parser as CsvParser;
 use crate::csv::infer_primitive_value;
+use crate::csv::parser::Config as CsvConfig;
+use crate::csv::Parser as CsvParser;
 use crate::error::{Error, ErrorKind, Result, Span};
 use crate::json::{Config as JsonConfig, Parser as JsonParser};
 use crate::toml::Parser as TomlParser;
@@ -24,6 +25,7 @@ pub enum Format {
 #[derive(Clone, Debug, Default)]
 pub struct ConvertOptions {
     pub json: JsonConfig,
+    pub csv: CsvConfig,
 }
 
 /// Convert between supported formats
@@ -97,7 +99,7 @@ fn parse_value(input: &str, format: Format, options: &ConvertOptions) -> Result<
             parser.parse_value()
         }
         Format::Csv => {
-            let mut parser = CsvParser::new(input.as_bytes());
+            let mut parser = CsvParser::with_config(input.as_bytes(), options.csv);
             parser.parse()
         }
         Format::Toml => {

--- a/crates/zparse/src/csv/parser.rs
+++ b/crates/zparse/src/csv/parser.rs
@@ -44,7 +44,7 @@ struct Field {
     quoted: bool,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Parser<'a> {
     input: &'a [u8],
     config: Config,
@@ -247,11 +247,12 @@ impl<'a> Parser<'a> {
 
                     index += 1;
 
+                    // Skip whitespace after closing quote, but NOT the delimiter
                     while index < self.input.len()
-                        && self
-                            .input
-                            .get(index)
-                            .is_some_and(|byte| matches!(*byte, b' ' | b'\t' | b'\x0c'))
+                        && self.input.get(index).is_some_and(|byte| {
+                            *byte != self.config.delimiter
+                                && matches!(*byte, b' ' | b'\t' | b'\x0c')
+                        })
                     {
                         index += 1;
                     }

--- a/crates/zparse/src/lib.rs
+++ b/crates/zparse/src/lib.rs
@@ -110,6 +110,23 @@ pub fn from_csv_bytes_with_config(bytes: &[u8], config: CsvConfig) -> Result<Val
     parser.parse()
 }
 
+/// Parse CSV from string with custom delimiter.
+///
+/// The `delimiter` can be any single byte except `\n`, `\r`, and `"`,
+/// which conflict with record separators and quoting rules.
+pub fn from_csv_str_with_delimiter(s: &str, delimiter: u8) -> Result<Value> {
+    let mut parser = CsvParser::with_delimiter(s.as_bytes(), delimiter);
+    parser.parse()
+}
+
+/// Parse CSV from bytes with custom delimiter.
+///
+/// The `delimiter` can be any single byte except `\n`, `\r`, and `"`,
+/// which conflict with record separators and quoting rules.
+pub fn from_csv_bytes_with_delimiter(bytes: &[u8], delimiter: u8) -> Result<Value> {
+    let mut parser = CsvParser::with_delimiter(bytes, delimiter);
+    parser.parse()
+}
 /// Parse TOML from string
 pub fn from_toml_str(s: &str) -> Result<Value> {
     let mut parser = TomlParser::new(s.as_bytes());

--- a/crates/zparse/tests/csv_tests.rs
+++ b/crates/zparse/tests/csv_tests.rs
@@ -203,6 +203,7 @@ fn jsonc_to_csv_strips_comments_and_trailing_commas() -> Result<(), Box<dyn std:
         json: JsonConfig::default()
             .with_comments(true)
             .with_trailing_commas(true),
+        ..Default::default()
     };
     let input = r#"
         // comment
@@ -227,6 +228,7 @@ fn csv_to_json_is_strict_json_output() -> Result<(), Box<dyn std::error::Error>>
         json: JsonConfig::default()
             .with_comments(true)
             .with_trailing_commas(true),
+        ..Default::default()
     };
     let output = convert_with_options("name,age\nAlice,30\n", Format::Csv, Format::Json, &options)?;
     expect_true(

--- a/crates/zparse/tests/csv_tests.rs
+++ b/crates/zparse/tests/csv_tests.rs
@@ -18,6 +18,17 @@ fn expect_true(cond: bool, message: &str) -> Result<(), Box<dyn std::error::Erro
     }
 }
 
+fn ensure_eq<T: std::cmp::PartialEq + std::fmt::Debug>(
+    left: T,
+    right: T,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if left == right {
+        Ok(())
+    } else {
+        Err(format!("{:?} != {:?}", left, right).into())
+    }
+}
+
 #[test]
 fn parse_basic_csv() -> Result<(), Box<dyn std::error::Error>> {
     let value = zparse::from_csv_str("name,age,active\nAlice,30,true\nBob,25,false\n")?;
@@ -298,5 +309,75 @@ fn csv_whitespace_only_returns_empty_array() -> Result<(), Box<dyn std::error::E
         arr.is_empty(),
         "whitespace-only CSV should return empty array",
     )?;
+    Ok(())
+}
+
+#[test]
+fn parse_csv_with_semicolon_delimiter() -> Result<(), Box<dyn std::error::Error>> {
+    let data = "name;age\nAlice;30\nBob;25";
+    let value = zparse::from_csv_str_with_delimiter(data, b';')?;
+    let arr = value.as_array().ok_or("expected array")?;
+    ensure_eq(arr.len(), 2)?;
+    let first = arr
+        .get(0)
+        .ok_or("missing first row")?
+        .as_object()
+        .ok_or("expected object")?;
+    ensure_eq(first.get("name"), Some(&Value::String("Alice".to_string())))?;
+    ensure_eq(first.get("age"), Some(&Value::Number(30.0)))?;
+    Ok(())
+}
+
+#[test]
+fn parse_csv_with_tab_delimiter() -> Result<(), Box<dyn std::error::Error>> {
+    let data = "name\tage\nCharlie\t28";
+    let value = zparse::from_csv_str_with_delimiter(data, b'\t')?;
+    let arr = value.as_array().ok_or("expected array")?;
+    ensure_eq(arr.len(), 1)?;
+    let first = arr
+        .get(0)
+        .ok_or("missing first row")?
+        .as_object()
+        .ok_or("expected object")?;
+    ensure_eq(
+        first.get("name"),
+        Some(&Value::String("Charlie".to_string())),
+    )?;
+    ensure_eq(first.get("age"), Some(&Value::Number(28.0)))?;
+    Ok(())
+}
+
+#[test]
+fn parse_csv_with_tab_delimiter_quoted_field() -> Result<(), Box<dyn std::error::Error>> {
+    let data = "name\tage\n\"Charlie\"\t28";
+    let value = zparse::from_csv_str_with_delimiter(data, b'\t')?;
+    let arr = value.as_array().ok_or("expected array")?;
+    ensure_eq(arr.len(), 1)?;
+    let first = arr
+        .get(0)
+        .ok_or("missing first row")?
+        .as_object()
+        .ok_or("expected object")?;
+    ensure_eq(
+        first.get("name"),
+        Some(&Value::String("Charlie".to_string())),
+    )?;
+    ensure_eq(first.get("age"), Some(&Value::Number(28.0)))?;
+    Ok(())
+}
+
+#[test]
+fn parse_csv_with_pipe_delimiter() -> Result<(), Box<dyn std::error::Error>> {
+    let data = "name|age\nDave|35";
+    let value = zparse::from_csv_str_with_delimiter(data, b'|')?;
+    let arr = value.as_array().ok_or("expected array")?;
+    ensure_eq(arr.len(), 1)?;
+    let first = arr
+        .get(0)
+        .ok_or("missing first row")?
+        .as_object()
+        .ok_or("expected object")?;
+    ensure_eq(first.get("name"), Some(&Value::String("Dave".to_string())))?;
+    ensure_eq(first.get("age"), Some(&Value::Number(35.0)))?;
     Ok(())
 }

--- a/crates/zparse/tests/jsonc_tests.rs
+++ b/crates/zparse/tests/jsonc_tests.rs
@@ -55,6 +55,7 @@ fn convert_jsonc_to_json_normalizes_to_strict_json() {
         json: Config::default()
             .with_comments(true)
             .with_trailing_commas(true),
+        ..Default::default()
     };
 
     let output = convert_with_options(input, Format::Json, Format::Json, &options);
@@ -77,6 +78,7 @@ fn convert_jsonc_to_toml_works() {
         json: Config::default()
             .with_comments(true)
             .with_trailing_commas(true),
+        ..Default::default()
     };
 
     let output = convert_with_options(input, Format::Json, Format::Toml, &options);


### PR DESCRIPTION
## Summary

Add support for custom CSV delimiters (comma, semicolon, tab, pipe) - Issue #70

## Changes

- Add `Parser::with_delimiter(input, delimiter)` constructor
- Add public API functions:
  - `from_csv_str_with_delimiter(s, delimiter)`
  - `from_csv_bytes_with_delimiter(bytes, delimiter)`

## Usage

```rust
// Semicolon delimiter
let value = zparse::from_csv_str_with_delimiter("name;age\nAlice;30", b';')?;

// Tab delimiter (TSV)
let value = zparse::from_csv_str_with_delimiter("name\tage\nBob\t25", b'\t')?;
```

## Tests

- Add tests for semicolon, tab, and pipe delimiters
- All existing tests pass

## Verification

- `cargo +nightly fmt --all` 
- `cargo clippy --all-targets --all-features`
- `cargo test --all-features` (all pass)