### PR TITLE
fix: tighten JSON/TOML parser limit accounting and diagnostics

### DIFF
--- a/crates/zparse/src/json/parser.rs
+++ b/crates/zparse/src/json/parser.rs
@@ -1,6 +1,6 @@
 //! JSON streaming parser implementation
 
-use crate::error::{Error, ErrorKind, Result};
+use crate::error::{Error, ErrorKind, Result, Span};
 use crate::json::event::Event;
 use crate::lexer::json::JsonLexer;
 use crate::lexer::{Token, TokenKind};
@@ -118,25 +118,10 @@ impl<'a> Parser<'a> {
 
     /// Get the next event from the parser
     pub fn next_event(&mut self) -> Result<Option<Event>> {
-        // Check size limit before processing
-        if self.config.max_size > 0 && self.bytes_parsed >= self.config.max_size {
-            return Err(Error::at(
-                ErrorKind::MaxSizeExceeded {
-                    max: self.config.max_size,
-                },
-                self.bytes_parsed,
-                1,
-                1,
-            ));
-        }
-
-        // Skip whitespace and get next token
         let token = self.lexer.next_token()?;
 
-        // Track bytes parsed based on token span
         let span = token.span;
-        let token_len = span.end.offset.saturating_sub(span.start.offset);
-        self.bytes_parsed = self.bytes_parsed.saturating_add(token_len);
+        self.bytes_parsed = span.end.offset;
 
         // Check size limit after updating
         if self.config.max_size > 0 && self.bytes_parsed > self.config.max_size {
@@ -145,8 +130,8 @@ impl<'a> Parser<'a> {
                     max: self.config.max_size,
                 },
                 self.bytes_parsed,
-                1,
-                1,
+                span.end.line,
+                span.end.col,
             ));
         }
 
@@ -281,13 +266,13 @@ impl<'a> Parser<'a> {
     fn handle_root(&mut self, token: Token) -> Result<Option<Event>> {
         match token.kind {
             TokenKind::LeftBrace => {
-                self.increment_depth()?;
+                self.increment_depth(token.span)?;
                 self.context_stack.push(ContainerContext::Object);
                 self.is_first_element = true;
                 Ok(Some(Event::ObjectStart))
             }
             TokenKind::LeftBracket => {
-                self.increment_depth()?;
+                self.increment_depth(token.span)?;
                 self.context_stack.push(ContainerContext::Array);
                 self.is_first_element = true;
                 Ok(Some(Event::ArrayStart))
@@ -398,7 +383,7 @@ impl<'a> Parser<'a> {
     fn parse_value_token(&mut self, token: Token) -> Result<Option<Event>> {
         match token.kind {
             TokenKind::LeftBrace => {
-                self.increment_depth()?;
+                self.increment_depth(token.span)?;
                 self.context_stack.push(ContainerContext::Object);
                 self.is_first_element = true;
                 self.expecting_colon_after_key = false;
@@ -407,7 +392,7 @@ impl<'a> Parser<'a> {
                 Ok(Some(Event::ObjectStart))
             }
             TokenKind::LeftBracket => {
-                self.increment_depth()?;
+                self.increment_depth(token.span)?;
                 self.context_stack.push(ContainerContext::Array);
                 self.is_first_element = true;
                 self.expecting_colon_after_key = false;
@@ -444,15 +429,15 @@ impl<'a> Parser<'a> {
         !self.is_first_element && !self.expecting_colon_after_key && !self.expecting_value
     }
 
-    fn increment_depth(&mut self) -> Result<()> {
+    fn increment_depth(&mut self, opening_span: Span) -> Result<()> {
         if self.config.max_depth > 0 && self.depth >= self.config.max_depth {
             return Err(Error::at(
                 ErrorKind::MaxDepthExceeded {
                     max: self.config.max_depth,
                 },
-                self.bytes_parsed,
-                1,
-                1,
+                opening_span.start.offset,
+                opening_span.start.line,
+                opening_span.start.col,
             ));
         }
         self.depth = self.depth.saturating_add(1);

--- a/crates/zparse/src/lexer/json.rs
+++ b/crates/zparse/src/lexer/json.rs
@@ -66,16 +66,13 @@ impl<'a> JsonLexer<'a> {
                 b't' => self.lex_true()?,
                 b'f' => self.lex_false()?,
                 b'-' | b'0'..=b'9' => self.lex_number()?,
-                b'/' if self.allow_comments => {
-                    self.skip_comment()?;
-                    return self.next_token();
-                }
                 _ => {
+                    let pos = self.cursor.position();
                     return Err(Error::at(
                         ErrorKind::InvalidToken,
-                        start.offset,
-                        start.line,
-                        start.col,
+                        pos.offset,
+                        pos.line,
+                        pos.col,
                     ));
                 }
             },

--- a/crates/zparse/src/lexer/toml.rs
+++ b/crates/zparse/src/lexer/toml.rs
@@ -54,7 +54,14 @@ impl<'a> TomlLexer<'a> {
 
     /// Get the next token from the input
     pub fn next_token(&mut self) -> Result<TomlToken> {
-        self.skip_space();
+        loop {
+            self.skip_space();
+            if self.cursor.current() == Some(b'#') {
+                self.skip_comment();
+                continue;
+            }
+            break;
+        }
 
         let start = self.cursor.position();
 
@@ -63,10 +70,6 @@ impl<'a> TomlLexer<'a> {
             Some(b'\n') => {
                 self.cursor.advance();
                 TomlTokenKind::Newline
-            }
-            Some(b'#') => {
-                self.skip_comment();
-                return self.next_token();
             }
             Some(b'[') => {
                 if self.cursor.peek(1) == Some(b'[') {

--- a/crates/zparse/src/toml/parser.rs
+++ b/crates/zparse/src/toml/parser.rs
@@ -134,8 +134,7 @@ impl<'a> Parser<'a> {
         };
 
         let span = token.span;
-        let token_len = span.end.offset.saturating_sub(span.start.offset);
-        self.bytes_parsed = self.bytes_parsed.saturating_add(token_len);
+        self.bytes_parsed = span.end.offset;
 
         if self.config.max_size > 0 && self.bytes_parsed > self.config.max_size {
             return Err(Error::at(
@@ -143,8 +142,8 @@ impl<'a> Parser<'a> {
                     max: self.config.max_size,
                 },
                 self.bytes_parsed,
-                1,
-                1,
+                span.end.line,
+                span.end.col,
             ));
         }
 

--- a/crates/zparse/tests/json_parser_tests.rs
+++ b/crates/zparse/tests/json_parser_tests.rs
@@ -394,6 +394,34 @@ fn test_depth_limit() -> Result<()> {
 }
 
 #[test]
+fn test_depth_limit_reports_opener_position() -> Result<()> {
+    let input = br#"{
+  "a": {
+    "b": {
+      "c": 1
+    }
+  }
+}"#;
+    let config = Config::new(2, 0);
+    let mut parser = Parser::with_config(input, config);
+
+    let result = parser.parse_value();
+    match result {
+        Err(err) if matches!(err.kind(), ErrorKind::MaxDepthExceeded { max: 2 }) => {
+            let pos = err.span().start;
+            if pos.line <= 1 {
+                return fail(format!(
+                    "expected opener line > 1 for depth error, got line {}",
+                    pos.line
+                ));
+            }
+            Ok(())
+        }
+        _ => fail("Expected max depth error with opener position".to_string()),
+    }
+}
+
+#[test]
 fn test_size_limit() -> Result<()> {
     let input = b"1234567890";
     let config = Config::new(0, 5); // max size of 5 bytes
@@ -405,6 +433,22 @@ fn test_size_limit() -> Result<()> {
         Err(err) if matches!(err.kind(), ErrorKind::MaxSizeExceeded { max: 5 })
     ) {
         return fail("Expected max size error".to_string());
+    }
+    Ok(())
+}
+
+#[test]
+fn test_size_limit_counts_ignorable_prefix_with_comments() -> Result<()> {
+    let input = b"/* very long comment prefix */\n123";
+    let config = Config::new(0, 10).with_comments(true);
+    let mut parser = Parser::with_config(input, config);
+
+    let result = parser.parse_value();
+    if !matches!(
+        result,
+        Err(err) if matches!(err.kind(), ErrorKind::MaxSizeExceeded { max: 10 })
+    ) {
+        return fail("Expected max size error counting ignorable prefix".to_string());
     }
     Ok(())
 }

--- a/crates/zparse/tests/toml_parser_tests.rs
+++ b/crates/zparse/tests/toml_parser_tests.rs
@@ -2,7 +2,7 @@ use time::format_description::well_known::Rfc3339;
 use time::macros::format_description;
 use time::{Date, OffsetDateTime, PrimitiveDateTime, Time};
 use zparse::error::{Error, ErrorKind, Result};
-use zparse::toml::parser::Parser;
+use zparse::toml::parser::{Config, Parser};
 use zparse::{Span, TomlDatetime, Value};
 
 fn ensure_eq<T: PartialEq + std::fmt::Debug>(left: T, right: T) -> Result<()> {
@@ -223,6 +223,27 @@ color = \"gray\"\n";
             ErrorKind::InvalidToken,
             Span::empty(),
             "expected object".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_size_limit_counts_ignorable_prefix() -> Result<()> {
+    let input = b"# long comment prefix\nkey = 1\n";
+    let config = Config::new(0, 10);
+    let mut parser = Parser::with_config(input, config);
+
+    let result = parser.parse();
+    if !matches!(
+        result,
+        Err(err) if matches!(err.kind(), ErrorKind::MaxSizeExceeded { max: 10 })
+    ) {
+        return Err(Error::with_message(
+            ErrorKind::InvalidToken,
+            Span::empty(),
+            "expected max-size error counting ignorable prefix".to_string(),
         ));
     }
 


### PR DESCRIPTION
## Summary
- fix JSON/TOML max-size accounting to use absolute consumed offsets so large whitespace/comment prefixes are counted correctly
- improve max-size and max-depth diagnostics to use token-derived positions instead of hard-coded `1:1`
- add regression coverage for ignorable-prefix size limits and JSON depth-opener position reporting

## What changed
- `json/parser.rs`
  - use token span end offset/line/col for `MaxSizeExceeded`
  - thread opener span into `increment_depth` and report `MaxDepthExceeded` at opener position
- `toml/parser.rs`
  - compute `bytes_parsed` from `token.span.end.offset`
  - report `MaxSizeExceeded` with token span end line/col
- `lexer/json.rs`, `lexer/toml.rs`
  - normalize tokenization flow to avoid recursive re-entry while preserving precise token positions
- tests
  - `json_parser_tests.rs`: add depth-position and ignorable-prefix max-size regressions
  - `toml_parser_tests.rs`: add ignorable-prefix max-size regression

## Why
Copilot post-merge review on #77 correctly flagged that parser-side limit diagnostics and accounting could be misleading/incomplete when lexers skip ignorable content before emitting tokens.

## Validation
- `cargo +nightly fmt --all`
- `cargo clippy --all-features --all-targets`
- `cargo test --all-features`